### PR TITLE
Make CheckableItems checkable on init

### DIFF
--- a/src/main/kotlin/com/kdroid/composetray/lib/linux/appindicator/Gtk.kt
+++ b/src/main/kotlin/com/kdroid/composetray/lib/linux/appindicator/Gtk.kt
@@ -23,5 +23,6 @@ internal interface Gtk : Library {
     fun gtk_widget_set_sensitive(widget: Pointer, sensitive: Int)
     fun gtk_widget_destroy(menu: Pointer)
     fun gtk_widget_hide(get: Pointer?)
+    fun gtk_check_menu_item_set_active(checkMenuItem: Pointer, active: Boolean)
 
 }

--- a/src/main/kotlin/com/kdroid/composetray/menu/api/TrayMenuBuilder.kt
+++ b/src/main/kotlin/com/kdroid/composetray/menu/api/TrayMenuBuilder.kt
@@ -2,7 +2,7 @@ package com.kdroid.composetray.menu.api
 
  interface TrayMenuBuilder {
     fun Item(label: String, isEnabled: Boolean = true, onClick: () -> Unit = {})
-    fun CheckableItem(label: String, isEnabled: Boolean = true, onToggle: (Boolean) -> Unit)
+    fun CheckableItem(label: String, checked: Boolean = false, isEnabled: Boolean = true, onToggle: (Boolean) -> Unit)
     fun SubMenu(label: String, isEnabled: Boolean = true, submenuContent: (TrayMenuBuilder.() -> Unit)?)
     fun Divider()
     fun dispose()

--- a/src/main/kotlin/com/kdroid/composetray/menu/impl/AwtTrayMenuBuilderImpl.kt
+++ b/src/main/kotlin/com/kdroid/composetray/menu/impl/AwtTrayMenuBuilderImpl.kt
@@ -16,8 +16,8 @@ internal class AwtTrayMenuBuilderImpl(private val popupMenu: PopupMenu, private 
         popupMenu.add(menuItem)
     }
 
-    override fun CheckableItem(label: String, isEnabled: Boolean, onToggle: (Boolean) -> Unit) {
-        var isChecked = false
+    override fun CheckableItem(label: String, checked:Boolean, isEnabled: Boolean, onToggle: (Boolean) -> Unit) {
+        var isChecked = checked
         val checkableMenuItem = MenuItem(getCheckableLabel(label, isChecked))
         checkableMenuItem.isEnabled = isEnabled
 

--- a/src/main/kotlin/com/kdroid/composetray/menu/impl/LinuxTrayMenuBuilderImpl.kt
+++ b/src/main/kotlin/com/kdroid/composetray/menu/impl/LinuxTrayMenuBuilderImpl.kt
@@ -61,10 +61,11 @@ class LinuxTrayMenuBuilderImpl(private val menu: Pointer) : TrayMenuBuilder {
         )
     }
 
-    override fun CheckableItem(label: String, isEnabled: Boolean, onToggle: (Boolean) -> Unit) {
+    override fun CheckableItem(label: String, checked: Boolean, isEnabled: Boolean, onToggle: (Boolean) -> Unit) {
         val checkMenuItem = Gtk.INSTANCE.gtk_check_menu_item_new_with_label(label)
         Gtk.INSTANCE.gtk_menu_shell_append(menu, checkMenuItem)
         Gtk.INSTANCE.gtk_widget_set_sensitive(checkMenuItem, if (isEnabled) 1 else 0)
+        Gtk.INSTANCE.gtk_check_menu_item_set_active(checkMenuItem, checked)
 
         val callback = object : GCallback {
             override fun callback(widget: Pointer, data: Pointer?) {

--- a/src/main/kotlin/com/kdroid/composetray/menu/impl/WindowsTrayMenuBuilderImpl.kt
+++ b/src/main/kotlin/com/kdroid/composetray/menu/impl/WindowsTrayMenuBuilderImpl.kt
@@ -28,8 +28,8 @@ internal class WindowsTrayMenuBuilderImpl(
         }
     }
 
-    override fun CheckableItem(label: String, isEnabled: Boolean, onToggle: (Boolean) -> Unit) {
-        var isChecked = false // Initialise l'état checked
+    override fun CheckableItem(label: String, checked: Boolean, isEnabled: Boolean, onToggle: (Boolean) -> Unit) {
+        var isChecked = checked // Initialise l'état checked
 
         lock.withLock {
             val menuItem = WindowsTrayManager.MenuItem(

--- a/src/test/kotlin/sample/DemoAdaptivePositionWindows.kt
+++ b/src/test/kotlin/sample/DemoAdaptivePositionWindows.kt
@@ -70,6 +70,9 @@ fun main() = application {
             CheckableItem(label = "Enable notifications") { isChecked ->
                 Log.i(logTag, "Notifications ${if (isChecked) "enabled" else "disabled"}")
             }
+            CheckableItem(label = "Initial Checked", checked = true) { isChecked ->
+                Log.i(logTag, "Initial Checked ${if (isChecked) "enabled" else "disabled"}")
+            }
 
             Divider()
 

--- a/src/test/kotlin/sample/DemoWithContextMenu.kt
+++ b/src/test/kotlin/sample/DemoWithContextMenu.kt
@@ -88,6 +88,9 @@ fun main() = application {
             CheckableItem(label = "Enable notifications") { isChecked ->
                 Log.i(logTag, "Notifications ${if (isChecked) "enabled" else "disabled"}")
             }
+            CheckableItem(label = "Initial Checked", checked = true) { isChecked ->
+                Log.i(logTag, "Initial Checked ${if (isChecked) "enabled" else "disabled"}")
+            }
 
             Divider()
 


### PR DESCRIPTION
CheckableItems were not initializable checked.

This PR adds a parameter to define if a CheckableItem should be checked when created.