### PR TITLE
Reload NativeTray on Tray parameter change

### DIFF
--- a/src/main/kotlin/com/kdroid/composetray/tray/api/NativeTray.kt
+++ b/src/main/kotlin/com/kdroid/composetray/tray/api/NativeTray.kt
@@ -54,7 +54,7 @@ fun ApplicationScope.Tray(
     primaryActionLinuxLabel: String = "Open",
     menuContent: (TrayMenuBuilder.() -> Unit)? = null
 ) {
-    DisposableEffect(Unit) {
+    DisposableEffect(iconPath, windowsIconPath, tooltip, primaryAction, primaryActionLinuxLabel, menuContent) {
         NativeTray(
             iconPath = iconPath,
             windowsIconPath = windowsIconPath,


### PR DESCRIPTION
Following previous recomposition support for icon visibility, this fixes #2 