### PR TITLE
Use URI strings instead of paths for tray icons

### DIFF
--- a/src/main/kotlin/com/kdroid/composetray/tray/api/NativeTray.kt
+++ b/src/main/kotlin/com/kdroid/composetray/tray/api/NativeTray.kt
@@ -2,6 +2,7 @@ package com.kdroid.composetray.tray.api
 
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.remember
 import androidx.compose.ui.window.ApplicationScope
 import com.kdroid.composetray.menu.api.TrayMenuBuilder
 import com.kdroid.composetray.tray.impl.AwtTrayInitializer
@@ -9,6 +10,7 @@ import com.kdroid.composetray.tray.impl.LinuxTrayInitializer
 import com.kdroid.composetray.tray.impl.WindowsTrayInitializer
 import com.kdroid.composetray.utils.OperatingSystem
 import com.kdroid.composetray.utils.PlatformUtils
+import com.kdroid.composetray.utils.extractToTempIfDifferent
 import com.kdroid.kmplog.Log
 import com.kdroid.kmplog.d
 import kotlinx.coroutines.CoroutineScope
@@ -54,10 +56,22 @@ fun ApplicationScope.Tray(
     primaryActionLinuxLabel: String = "Open",
     menuContent: (TrayMenuBuilder.() -> Unit)? = null
 ) {
-    DisposableEffect(iconPath, windowsIconPath, tooltip, primaryAction, primaryActionLinuxLabel, menuContent) {
+    val absoluteIconPath = remember(iconPath) { extractToTempIfDifferent(iconPath)?.absolutePath.orEmpty() }
+    val absoluteWindowsIconPath = remember(iconPath, windowsIconPath) {
+        if (windowsIconPath == iconPath) absoluteIconPath
+        else extractToTempIfDifferent(windowsIconPath)?.absolutePath.orEmpty()
+    }
+    DisposableEffect(
+        absoluteIconPath,
+        absoluteWindowsIconPath,
+        tooltip,
+        primaryAction,
+        primaryActionLinuxLabel,
+        menuContent
+    ) {
         NativeTray(
-            iconPath = iconPath,
-            windowsIconPath = windowsIconPath,
+            iconPath = absoluteIconPath,
+            windowsIconPath = absoluteWindowsIconPath,
             tooltip = tooltip,
             primaryAction = primaryAction,
             primaryActionLinuxLabel = primaryActionLinuxLabel,

--- a/src/main/kotlin/com/kdroid/composetray/utils/JarResourceExtractor.kt
+++ b/src/main/kotlin/com/kdroid/composetray/utils/JarResourceExtractor.kt
@@ -1,0 +1,91 @@
+package com.kdroid.composetray.utils
+
+import java.io.File
+import java.io.FileNotFoundException
+import java.io.InputStream
+import java.net.URI
+import java.net.URLDecoder
+import java.nio.file.Files
+import java.nio.file.StandardCopyOption
+import java.security.MessageDigest
+import java.util.jar.JarFile
+import kotlin.io.path.createTempFile
+
+
+internal fun extractToTempIfDifferent(jarPath: String): File? {
+    // Analyze the path to get the file path and the entry path
+    val correctedJarFilePath =
+        URLDecoder.decode(jarPath.substringAfter("jar:file:").substringBefore("!"), Charsets.UTF_8.name())
+
+    // Encode special characters to be URI compatible
+    val encodedJarFilePath = correctedJarFilePath.replace(" ", "%20")
+
+    // Convert the path to File via URI
+    val jarFile = try {
+        File(URI(encodedJarFilePath))
+    } catch (e: IllegalArgumentException) {
+        File(correctedJarFilePath.removePrefix("file:"))
+    }
+
+    // Check if the file exists
+    if (!jarFile.exists()) {
+        throw FileNotFoundException("File does not exist: $correctedJarFilePath")
+    }
+
+    val entryPath = jarPath.substringAfter("!").trimStart('/')
+
+    // If the file is not a JAR, handle it differently
+    if (!correctedJarFilePath.endsWith(".jar")) {
+        val tempFile = createTempFile("extracted_", ".tmp").toFile().apply {
+            deleteOnExit()
+        }
+
+        // Copy the file directly if it is not a JAR
+        Files.copy(jarFile.toPath(), tempFile.toPath(), StandardCopyOption.REPLACE_EXISTING)
+        return tempFile
+    }
+
+    // Open the JAR from the absolute path
+    JarFile(jarFile).use { jar ->
+        val entry = jar.getJarEntry(entryPath) ?: return null
+
+        // Create a temporary file to store the extracted resource
+        val tempFile = createTempFile("extracted_", ".tmp").toFile().apply {
+            deleteOnExit()
+        }
+
+        // Check if the temporary file already exists and compare the hash
+        if (tempFile.exists()) {
+            val tempFileHash = tempFile.sha256()
+            jar.getInputStream(entry).use { input ->
+                val jarEntryHash = input.sha256()
+                // If the hash is identical, no need to copy again
+                if (tempFileHash == jarEntryHash) {
+                    return tempFile
+                }
+            }
+        }
+
+        // Copy the content of the JAR entry to the temporary file
+        jar.getInputStream(entry).use { input ->
+            Files.copy(input, tempFile.toPath(), StandardCopyOption.REPLACE_EXISTING)
+        }
+
+        return tempFile
+    }
+}
+
+
+// Extension to calculate SHA-256 of a file
+private fun File.sha256(): String = inputStream().use { it.sha256() }
+
+// Extension to calculate SHA-256 of an InputStream
+private fun InputStream.sha256(): String {
+    val digest = MessageDigest.getInstance("SHA-256")
+    val buffer = ByteArray(1024)
+    var bytesRead: Int
+    while (this.read(buffer).also { bytesRead = it } != -1) {
+        digest.update(buffer, 0, bytesRead)
+    }
+    return digest.digest().joinToString("") { "%02x".format(it) }
+}


### PR DESCRIPTION
Like done in the repo [ComposeNativeNotification](https://github.com/kdroidFilter/ComposeNativeNotification), extract absolute paths for icons to allow usage of resources from the JAR