### PR TITLE
Update demo run configurations and optimize imports

### DIFF
--- a/.run/DemoAdaptivePosition.run.xml
+++ b/.run/DemoAdaptivePosition.run.xml
@@ -1,0 +1,24 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="DemoAdaptivePosition" type="GradleRunConfiguration" factoryName="Gradle">
+    <ExternalSystemSettings>
+      <option name="executionName" />
+      <option name="externalProjectPath" value="$PROJECT_DIR$/demo" />
+      <option name="externalSystemIdString" value="GRADLE" />
+      <option name="scriptParameters" value="-DmainClass=com.kdroid.composetray.demo.DemoAdaptivePositionWindowsKt --quiet" />
+      <option name="taskDescriptions">
+        <list />
+      </option>
+      <option name="taskNames">
+        <list>
+          <option value="jvmRun" />
+        </list>
+      </option>
+      <option name="vmOptions" />
+    </ExternalSystemSettings>
+    <ExternalSystemDebugServerProcess>false</ExternalSystemDebugServerProcess>
+    <ExternalSystemReattachDebugProcess>true</ExternalSystemReattachDebugProcess>
+    <DebugAllEnabled>false</DebugAllEnabled>
+    <RunAsTest>false</RunAsTest>
+    <method v="2" />
+  </configuration>
+</component>

--- a/.run/DemoDynamicTray.run.xml
+++ b/.run/DemoDynamicTray.run.xml
@@ -1,0 +1,24 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="DemoDynamicTray" type="GradleRunConfiguration" factoryName="Gradle">
+    <ExternalSystemSettings>
+      <option name="executionName" />
+      <option name="externalProjectPath" value="$PROJECT_DIR$/demo" />
+      <option name="externalSystemIdString" value="GRADLE" />
+      <option name="scriptParameters" value="" />
+      <option name="taskDescriptions">
+        <list />
+      </option>
+      <option name="taskNames">
+        <list>
+          <option value="run" />
+        </list>
+      </option>
+      <option name="vmOptions" />
+    </ExternalSystemSettings>
+    <ExternalSystemDebugServerProcess>true</ExternalSystemDebugServerProcess>
+    <ExternalSystemReattachDebugProcess>true</ExternalSystemReattachDebugProcess>
+    <DebugAllEnabled>false</DebugAllEnabled>
+    <RunAsTest>false</RunAsTest>
+    <method v="2" />
+  </configuration>
+</component>

--- a/.run/DemoWithContextMenu.run.xml
+++ b/.run/DemoWithContextMenu.run.xml
@@ -1,0 +1,24 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="DemoWithContextMenu" type="GradleRunConfiguration" factoryName="Gradle">
+    <ExternalSystemSettings>
+      <option name="executionName" />
+      <option name="externalProjectPath" value="$PROJECT_DIR$/demo" />
+      <option name="externalSystemIdString" value="GRADLE" />
+      <option name="scriptParameters" value="-DmainClass=com.kdroid.composetray.demo.DemoWithoutContextMenuKt --quiet" />
+      <option name="taskDescriptions">
+        <list />
+      </option>
+      <option name="taskNames">
+        <list>
+          <option value="jvmRun" />
+        </list>
+      </option>
+      <option name="vmOptions" />
+    </ExternalSystemSettings>
+    <ExternalSystemDebugServerProcess>false</ExternalSystemDebugServerProcess>
+    <ExternalSystemReattachDebugProcess>true</ExternalSystemReattachDebugProcess>
+    <DebugAllEnabled>false</DebugAllEnabled>
+    <RunAsTest>false</RunAsTest>
+    <method v="2" />
+  </configuration>
+</component>

--- a/.run/DemoWithoutContextMenu.run.xml
+++ b/.run/DemoWithoutContextMenu.run.xml
@@ -1,5 +1,5 @@
 <component name="ProjectRunConfigurationManager">
-  <configuration default="false" name="DemoWithContextMenu" type="GradleRunConfiguration" factoryName="Gradle">
+  <configuration default="false" name="DemoWithoutContextMenu" type="GradleRunConfiguration" factoryName="Gradle">
     <ExternalSystemSettings>
       <option name="executionName" />
       <option name="externalProjectPath" value="$PROJECT_DIR$/demo" />

--- a/demo/src/jvmMain/kotlin/com/kdroid/composetray/demo/DemoWithContextMenu.kt
+++ b/demo/src/jvmMain/kotlin/com/kdroid/composetray/demo/DemoWithContextMenu.kt
@@ -10,7 +10,6 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.window.Window
 import androidx.compose.ui.window.application
 import com.kdroid.composetray.tray.api.Tray

--- a/demo/src/jvmMain/kotlin/com/kdroid/composetray/demo/DynamicTrayMenu.kt
+++ b/demo/src/jvmMain/kotlin/com/kdroid/composetray/demo/DynamicTrayMenu.kt
@@ -1,19 +1,10 @@
 package com.kdroid.composetray.demo
 
 import androidx.compose.foundation.Image
-import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
-import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
-import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.res.painterResource
-import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Window
 import androidx.compose.ui.window.application
 import com.kdroid.composetray.tray.api.Tray
@@ -53,7 +44,7 @@ fun main() = application {
     }
 
     val running = serviceStatus == ServiceStatus.RUNNING
-    var icon by mutableStateOf(Res.drawable.icon)
+    var icon by remember {   mutableStateOf(Res.drawable.icon) }
 
     if (alwaysShowTray || !isWindowVisible) {
         Tray(


### PR DESCRIPTION
### Changes Introduced
- Renamed the Gradle run configuration to `DemoWithoutContextMenu` for better clarity and alignment with the demo's purpose.
- Added specific Gradle run configurations for demo modules: `DemoAdaptivePosition`, `DemoDynamicTray`, and `DemoWithContextMenu`, simplifying debugging and execution.
- Optimized imports by removing unused ones, improving code readability.
- Enhanced state management by replacing `mutableStateOf` with `remember { mutableStateOf(...) }`, ensuring proper state handling across recompositions.
