### PR TITLE
Add ProGuard sample and cleanup unused plugin

### DIFF
--- a/demo/build.gradle.kts
+++ b/demo/build.gradle.kts
@@ -32,5 +32,11 @@ compose.desktop {
             packageName = "tray-demo"
             packageVersion = "1.0.0"
         }
+        buildTypes.release.proguard {
+            isEnabled = true
+            obfuscate.set(false)
+            optimize.set(true)
+            configurationFiles.from(project.file("proguard-rules.pro"))
+        }
     }
 }

--- a/demo/proguard-rules.pro
+++ b/demo/proguard-rules.pro
@@ -1,0 +1,77 @@
+-keepclasseswithmembers public class com.kdroid.composetray.demo.DynamicTrayMenuKt {  #
+    public static void main(java.lang.String[]);
+}
+
+-dontwarn kotlinx.coroutines.debug.*
+
+-keep class kotlin.** { *; }
+-keep class kotlinx.** { *; }
+-keep class kotlinx.coroutines.** { *; }
+-keep class org.jetbrains.skia.** { *; }
+-keep class org.jetbrains.skiko.** { *; }
+-keep class com.sun.jna.** { *; }
+-keep class * implements com.sun.jna.** { *; }
+-keepclassmembers class * extends com.sun.jna.* { public *; }
+-keepclassmembers class * implements com.sun.jna.* { public *; }
+-dontwarn com.sun.jna.**
+
+# Keep specific JNA Platform classes used in the project
+-keep class com.sun.jna.platform.** { *; }
+-keep class com.sun.jna.win32.** { *; }
+-dontwarn com.sun.jna.platform.**
+
+
+-keep class com.kdroid.composetray.** { *; }
+
+-assumenosideeffects public class androidx.compose.runtime.ComposerKt {
+    void sourceInformation(androidx.compose.runtime.Composer,java.lang.String);
+    void sourceInformationMarkerStart(androidx.compose.runtime.Composer,int,java.lang.String);
+    void sourceInformationMarkerEnd(androidx.compose.runtime.Composer);
+}
+
+# Keep `Companion` object fields of serializable classes.
+# This avoids serializer lookup through `getDeclaredClasses` as done for named companion objects.
+-if @kotlinx.serialization.Serializable class **
+-keepclassmembers class <1> {
+    static <1>$Companion Companion;
+}
+
+# Keep `serializer()` on companion objects (both default and named) of serializable classes.
+-if @kotlinx.serialization.Serializable class ** {
+    static **$* *;
+}
+-keepclassmembers class <2>$<3> {
+    kotlinx.serialization.KSerializer serializer(...);
+}
+
+# Keep `INSTANCE.serializer()` of serializable objects.
+-if @kotlinx.serialization.Serializable class ** {
+    public static ** INSTANCE;
+}
+-keepclassmembers class <1> {
+    public static <1> INSTANCE;
+    kotlinx.serialization.KSerializer serializer(...);
+}
+
+# @Serializable and @Polymorphic are used at runtime for polymorphic serialization.
+-keepattributes RuntimeVisibleAnnotations,AnnotationDefault
+
+-keepattributes *Annotation*, InnerClasses
+-dontnote kotlinx.serialization.AnnotationsKt # core serialization annotations
+-dontnote kotlinx.serialization.SerializationKt
+
+
+# OkHttp platform used only on JVM and when Conscrypt and other security providers are available.
+-dontwarn okhttp3.internal.platform.**
+-dontwarn org.conscrypt.**
+-dontwarn org.bouncycastle.**
+-dontwarn org.openjsse.**
+#################################### SLF4J #####################################
+-dontwarn org.slf4j.**
+
+# Prevent runtime crashes from use of class.java.getName()
+-dontwarn javax.naming.**
+
+# Ignore warnings and Don't obfuscate for now
+-dontobfuscate
+-ignorewarnings

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -32,9 +32,4 @@ dependencyResolutionManagement {
     }
 }
 
-plugins {
-    id("org.gradle.toolchains.foojay-resolver-convention") version "0.9.0"
-}
-
-
 include(":demo")


### PR DESCRIPTION
### Description

- Added a ProGuard sample to enhance configuration clarity for builds.
- Removed the unused Foojay resolver convention plugin from `settings.gradle.kts`, simplifying the build script without affecting functionality.
