### PR TITLE
Refactor Tray composable for unified visibility management

### DIFF
--- a/demo/src/jvmMain/kotlin/com/kdroid/composetray/demo/DemoAdaptivePositionWindows.kt
+++ b/demo/src/jvmMain/kotlin/com/kdroid/composetray/demo/DemoAdaptivePositionWindows.kt
@@ -47,15 +47,19 @@ fun main() = application {
     }
 
 
-    // Updated condition for Tray visibility
-    if (alwaysShowTray || !isWindowVisible) {
+    // Always create the Tray composable, but make it conditional on visibility
+    // This ensures it's recomposed when alwaysShowTray changes
+    val showTray = alwaysShowTray || !isWindowVisible
+
+    if (showTray) {
+        // Use alwaysShowTray as a key to force recomposition when it changes
         Tray(
            iconContent = {
                Image(
                    Icons.Default.Notifications,
                    contentDescription = "Application Icon",
                    modifier = Modifier.fillMaxSize(),
-                   colorFilter = ColorFilter.tint(Color.White)
+                   colorFilter = ColorFilter.tint(if (alwaysShowTray) Color.White else Color.White)
                )
            },
             primaryAction = {
@@ -94,12 +98,12 @@ fun main() = application {
 
             Divider()
 
-            CheckableItem(label = "Always show tray") { isChecked ->
+            CheckableItem(label = "Always show tray", checked = alwaysShowTray) { isChecked ->
                 alwaysShowTray = isChecked
                 Log.i(logTag, "Always show tray ${if (isChecked) "enabled" else "disabled"}")
             }
 
-            CheckableItem(label = "Hide on close") { isChecked ->
+            CheckableItem(label = "Hide on close", checked = hideOnClose) { isChecked ->
                 hideOnClose = isChecked
                 Log.i(logTag, "Hide on close ${if (isChecked) "enabled" else "disabled"}")
             }

--- a/demo/src/jvmMain/kotlin/com/kdroid/composetray/demo/DemoWithContextMenu.kt
+++ b/demo/src/jvmMain/kotlin/com/kdroid/composetray/demo/DemoWithContextMenu.kt
@@ -41,14 +41,18 @@ fun main() = application {
         return@application
     }
 
-    // Updated condition for Tray visibility
-    if (alwaysShowTray || !isWindowVisible) {
+    // Always create the Tray composable, but make it conditional on visibility
+    // This ensures it's recomposed when alwaysShowTray changes
+    val showTray = alwaysShowTray || !isWindowVisible
+
+    if (showTray) {
         Tray(
             iconContent = {
                 Icon(
                     Icons.Default.Favorite,
                     contentDescription = "",
-                    tint = Color.White,
+                    // Use alwaysShowTray as a key to force recomposition when it changes
+                    tint = if (alwaysShowTray) Color.White else Color.White,
                     modifier = Modifier.fillMaxSize()
                 )
             },
@@ -109,12 +113,12 @@ fun main() = application {
 
             Divider()
 
-            CheckableItem(label = "Always show tray") { isChecked ->
+            CheckableItem(label = "Always show tray", checked = alwaysShowTray) { isChecked ->
                 alwaysShowTray = isChecked
                 Log.i(logTag, "Always show tray ${if (isChecked) "enabled" else "disabled"}")
             }
 
-            CheckableItem(label = "Hide on close") { isChecked ->
+            CheckableItem(label = "Hide on close", checked = hideOnClose) { isChecked ->
                 hideOnClose = isChecked
                 Log.i(logTag, "Hide on close ${if (isChecked) "enabled" else "disabled"}")
             }

--- a/demo/src/jvmMain/kotlin/com/kdroid/composetray/demo/DemoWithoutContextMenu.kt
+++ b/demo/src/jvmMain/kotlin/com/kdroid/composetray/demo/DemoWithoutContextMenu.kt
@@ -43,11 +43,16 @@ fun main() = application {
         return@application
     }
 
-    // Updated condition for Tray visibility
-    if (alwaysShowTray || !isWindowVisible) {
+    // Always create the Tray composable, but make it conditional on visibility
+    // This ensures it's recomposed when alwaysShowTray changes
+    val showTray = alwaysShowTray || !isWindowVisible
+
+    if (showTray) {
         Tray(
             iconContent = {
-                Box(modifier = Modifier.fillMaxSize().clip(RoundedCornerShape(300.dp)).background(Color.Red.copy(alpha = 0.5f)))
+                // Use alwaysShowTray as a key to force recomposition when it changes
+                val alpha = if (alwaysShowTray) 0.5f else 0.5f
+                Box(modifier = Modifier.fillMaxSize().clip(RoundedCornerShape(300.dp)).background(Color.Red.copy(alpha = alpha)))
             },
             primaryAction = {
                 isWindowVisible = true

--- a/demo/src/jvmMain/kotlin/com/kdroid/composetray/demo/DynamicTrayMenu.kt
+++ b/demo/src/jvmMain/kotlin/com/kdroid/composetray/demo/DynamicTrayMenu.kt
@@ -46,12 +46,18 @@ fun main() = application {
     val running = serviceStatus == ServiceStatus.RUNNING
     var icon by remember {   mutableStateOf(Res.drawable.icon) }
 
-    if (alwaysShowTray || !isWindowVisible) {
+    // Always create the Tray composable, but make it conditional on visibility
+    // This ensures it's recomposed when alwaysShowTray changes
+    val showTray = alwaysShowTray || !isWindowVisible
+
+    if (showTray) {
         Tray(
             iconContent = {
                 Image(
                     painter = painterResource(icon),
                     contentDescription = "Application Icon",
+                    // Use alwaysShowTray as a key to force recomposition when it changes
+                    colorFilter = if (alwaysShowTray) null else null
                 )
             },
             primaryAction = {
@@ -95,6 +101,18 @@ fun main() = application {
 
                 Item(label = "About") {
                     Log.i(logTag, "Application v1.0 - Developed by Elyahou")
+                }
+
+                Divider()
+
+                CheckableItem(label = "Always show tray", checked = alwaysShowTray) { isChecked ->
+                    alwaysShowTray = isChecked
+                    Log.i(logTag, "Always show tray ${if (isChecked) "enabled" else "disabled"}")
+                }
+
+                CheckableItem(label = "Hide on close", checked = hideOnClose) { isChecked ->
+                    hideOnClose = isChecked
+                    Log.i(logTag, "Hide on close ${if (isChecked) "enabled" else "disabled"}")
                 }
 
                 Divider()


### PR DESCRIPTION
This pull request refactors the Tray composable to standardize its visibility handling logic across all demos. These changes include:

- Introducing a `showTray` variable to manage and standardize Tray visibility.
- Enforcing proper recomposition when `alwaysShowTray` changes.
- Adding explicit state binding for checkable items like "Always show tray" and "Hide on close."

These updates enhance maintainability and clarity in the codebase.