### PR TITLE
Icon scaling and aliasing, public exposure of icon render properties.

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,10 +63,11 @@ application {
       Icon(
         Icons.Default.Favorite,
         contentDescription = "",
-        tint = Color.White,
+        tint = Color.Unspecified, // If not defined icon will be tinted with LocalContentColor.current
         modifier = Modifier.fillMaxSize() // This is crucial!
       )
     },
+    iconRenderProperties = IconRenderProperties.forCurrentOperatingSystem(), // If you need icon render customization
     tooltip = "My Application",
     primaryAction = {
       Log.i(logTag, "Primary action triggered")

--- a/demo/src/jvmMain/kotlin/com/kdroid/composetray/demo/DemoAdaptivePositionWindows.kt
+++ b/demo/src/jvmMain/kotlin/com/kdroid/composetray/demo/DemoAdaptivePositionWindows.kt
@@ -16,6 +16,7 @@ import androidx.compose.ui.window.Window
 import androidx.compose.ui.window.application
 import androidx.compose.ui.window.rememberWindowState
 import com.kdroid.composetray.tray.api.Tray
+import com.kdroid.composetray.utils.IconRenderProperties
 import com.kdroid.composetray.utils.SingleInstanceManager
 import com.kdroid.composetray.utils.getTrayPosition
 import com.kdroid.composetray.utils.getTrayWindowPosition
@@ -59,9 +60,10 @@ fun main() = application {
                    Icons.Default.Notifications,
                    contentDescription = "Application Icon",
                    modifier = Modifier.fillMaxSize(),
-                   colorFilter = ColorFilter.tint(if (alwaysShowTray) Color.White else Color.White)
+                   colorFilter = ColorFilter.tint(if (alwaysShowTray) Color.Unspecified else Color.Unspecified)
                )
            },
+            iconRenderProperties = IconRenderProperties.forCurrentOperatingSystem(),
             primaryAction = {
                 isWindowVisible = true
                 Log.i(logTag, "On Primary Clicked")

--- a/demo/src/jvmMain/kotlin/com/kdroid/composetray/demo/DemoWithContextMenu.kt
+++ b/demo/src/jvmMain/kotlin/com/kdroid/composetray/demo/DemoWithContextMenu.kt
@@ -13,6 +13,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.window.Window
 import androidx.compose.ui.window.application
 import com.kdroid.composetray.tray.api.Tray
+import com.kdroid.composetray.utils.IconRenderProperties
 import com.kdroid.composetray.utils.SingleInstanceManager
 import com.kdroid.composetray.utils.getTrayPosition
 import com.kdroid.kmplog.Log
@@ -52,10 +53,11 @@ fun main() = application {
                     Icons.Default.Favorite,
                     contentDescription = "",
                     // Use alwaysShowTray as a key to force recomposition when it changes
-                    tint = if (alwaysShowTray) Color.White else Color.White,
+                    tint = if (alwaysShowTray) Color.Unspecified else Color.Unspecified,
                     modifier = Modifier.fillMaxSize()
                 )
             },
+            iconRenderProperties = IconRenderProperties.forCurrentOperatingSystem(),
             primaryAction = {
                 isWindowVisible = true
                 Log.i(logTag, "On Primary Clicked")

--- a/demo/src/jvmMain/kotlin/com/kdroid/composetray/demo/DemoWithoutContextMenu.kt
+++ b/demo/src/jvmMain/kotlin/com/kdroid/composetray/demo/DemoWithoutContextMenu.kt
@@ -10,11 +10,11 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Window
 import androidx.compose.ui.window.application
 import com.kdroid.composetray.tray.api.Tray
+import com.kdroid.composetray.utils.IconRenderProperties
 import com.kdroid.composetray.utils.SingleInstanceManager
 import com.kdroid.composetray.utils.getTrayPosition
 import com.kdroid.kmplog.Log
@@ -54,6 +54,7 @@ fun main() = application {
                 val alpha = if (alwaysShowTray) 0.5f else 0.5f
                 Box(modifier = Modifier.fillMaxSize().clip(RoundedCornerShape(300.dp)).background(Color.Red.copy(alpha = alpha)))
             },
+            iconRenderProperties = IconRenderProperties.forCurrentOperatingSystem(),
             primaryAction = {
                 isWindowVisible = true
                 Log.i(logTag, "On Primary Clicked")

--- a/demo/src/jvmMain/kotlin/com/kdroid/composetray/demo/DynamicTrayMenu.kt
+++ b/demo/src/jvmMain/kotlin/com/kdroid/composetray/demo/DynamicTrayMenu.kt
@@ -8,6 +8,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.window.Window
 import androidx.compose.ui.window.application
 import com.kdroid.composetray.tray.api.Tray
+import com.kdroid.composetray.utils.IconRenderProperties
 import com.kdroid.composetray.utils.SingleInstanceManager
 import com.kdroid.composetray.utils.getTrayPosition
 import com.kdroid.kmplog.Log
@@ -60,6 +61,7 @@ fun main() = application {
                     colorFilter = if (alwaysShowTray) null else null
                 )
             },
+            iconRenderProperties = IconRenderProperties.forCurrentOperatingSystem(),
             primaryAction = {
                 isWindowVisible = true
                 Log.i(logTag, "On Primary Clicked")

--- a/src/commonMain/kotlin/com/kdroid/composetray/utils/ComposableIconUtils.kt
+++ b/src/commonMain/kotlin/com/kdroid/composetray/utils/ComposableIconUtils.kt
@@ -2,11 +2,14 @@ package com.kdroid.composetray.utils
 
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.ImageComposeScene
-import androidx.compose.ui.unit.Density
+import androidx.compose.ui.use
 import kotlinx.coroutines.Dispatchers
 import org.jetbrains.skia.Bitmap
 import org.jetbrains.skia.EncodedImageFormat
+import org.jetbrains.skia.FilterMipmap
+import org.jetbrains.skia.FilterMode
 import org.jetbrains.skia.Image
+import org.jetbrains.skia.MipmapMode
 import java.io.File
 import java.util.zip.CRC32
 
@@ -18,69 +21,99 @@ object ComposableIconUtils {
     /**
      * Renders a Composable to a PNG file and returns the path to the file.
      *
-     * @param width Width of the image in pixels
-     * @param height Height of the image in pixels
-     * @param density Density factor for rendering
+     * @param iconRenderProperties Properties for rendering the icon
      * @param content The Composable content to render
      * @return Path to the generated PNG file
      */
     fun renderComposableToPngFile(
-        width: Int = 200,
-        height: Int = 200,
-        density: Float = 2f,
+        iconRenderProperties: IconRenderProperties,
         content: @Composable () -> Unit
     ): String {
         val tempFile = createTempFile(suffix = ".png")
-        val pngData = renderComposableToPngBytes(width, height, density, content)
+        val pngData = renderComposableToPngBytes(iconRenderProperties, content)
         tempFile.writeBytes(pngData)
         return tempFile.absolutePath
     }
 
-
+    /**
+     * Renders a Composable to a PNG image and returns the result as a byte array.
+     *
+     * This function creates an [ImageComposeScene] based on the provided [IconRenderProperties],
+     * renders the Composable content, and encodes the output into PNG format.
+     * If scaling is required based on the [IconRenderProperties], the rendered content is scaled before encoding.
+     *
+     * @param iconRenderProperties Properties for rendering the icon
+     * @param content The Composable content to render
+     * @return A byte array containing the rendered PNG image data.
+     */
     fun renderComposableToPngBytes(
-        width: Int = 200,
-        height: Int = 200,
-        density: Float = 2f,
+        iconRenderProperties: IconRenderProperties,
         content: @Composable () -> Unit
     ): ByteArray {
         val scene = ImageComposeScene(
-            width = width,
-            height = height,
-            density = Density(density),
+            width = iconRenderProperties.sceneWidth,
+            height = iconRenderProperties.sceneHeight,
+            density = iconRenderProperties.sceneDensity,
             coroutineContext = Dispatchers.Unconfined
         ) {
             content()
         }
 
-        val img = scene.render()
-        val bitmap = Bitmap.makeFromImage(img)
-        val data = Image.makeFromBitmap(bitmap).use { image ->
-            image.encodeToData(EncodedImageFormat.PNG)!!
+        val renderedIcon = scene.use { it.render() }
+
+        val iconData = if (iconRenderProperties.requiresScaling) {
+            val scaledIcon = Bitmap().apply {
+                allocN32Pixels(iconRenderProperties.targetWidth, iconRenderProperties.targetHeight)
+            }
+            renderedIcon.use {
+                it.scalePixels(scaledIcon.peekPixels()!!, FilterMipmap(FilterMode.LINEAR, MipmapMode.LINEAR), true)
+            }
+            scaledIcon.use { bitmap ->
+                Image.makeFromBitmap(bitmap).use { image ->
+                    image.encodeToData(EncodedImageFormat.PNG)!!
+                }
+            }
+        } else {
+            renderedIcon.use { image ->
+                image.encodeToData(EncodedImageFormat.PNG)!!
+            }
         }
 
-        return data.bytes
+        return iconData.bytes
     }
 
+    /**
+     * Renders a Composable to an ICO file and returns the path to the file.
+     *
+     * @param iconRenderProperties Properties for rendering the icon
+     * @param content The Composable content to render
+     * @return Path to the generated PNG file
+     */
+    fun renderComposableToIcoFile(
+        iconRenderProperties: IconRenderProperties,
+        content: @Composable (() -> Unit)
+    ): String {
+        val tempFile = createTempFile(suffix = ".ico")
+        val icoData = renderComposableToIcoBytes(iconRenderProperties, content)
+        tempFile.writeBytes(icoData)
+        return tempFile.absolutePath
+    }
 
     /**
      * Renders a Composable to ICO format bytes.
      * Since ICO format is not directly supported by the encoding library,
      * this method first renders to PNG and then creates a simple ICO wrapper.
      *
-     * @param width Width of the image in pixels
-     * @param height Height of the image in pixels
-     * @param density Density factor for rendering
+     * @param iconRenderProperties Properties for rendering the icon
      * @param content The Composable content to render
      * @return Byte array containing the ICO data
      */
     fun renderComposableToIcoBytes(
-        width: Int = 200,
-        height: Int = 200,
-        density: Float = 2f,
+        iconRenderProperties: IconRenderProperties,
         content: @Composable () -> Unit
     ): ByteArray {
         // First render to PNG format (which is supported)
-        val pngBytes = renderComposableToPngBytes(width, height, density, content)
+        val pngBytes = renderComposableToPngBytes(iconRenderProperties, content)
 
         // Create a simple ICO format wrapper around the PNG data
         // ICO header (6 bytes) + ICO directory entry (16 bytes) + PNG data
@@ -97,8 +130,8 @@ object ComposableIconUtils {
         icoData[5] = 0 // Number of images (high byte)
 
         // ICO directory entry
-        icoData[6] = width.toByte() // Width (0 means 256)
-        icoData[7] = height.toByte() // Height (0 means 256)
+        icoData[6] = iconRenderProperties.targetWidth.toByte() // Width (0 means 256)
+        icoData[7] = iconRenderProperties.targetHeight.toByte() // Height (0 means 256)
         icoData[8] = 0 // Color palette size (0 for no palette)
         icoData[9] = 0 // Reserved, must be 0
         icoData[10] = 1 // Color planes
@@ -139,21 +172,17 @@ object ComposableIconUtils {
      * Calculates a hash value for the rendered composable content.
      * This can be used to detect changes in the composable content without requiring an explicit key.
      *
-     * @param width Width of the image in pixels
-     * @param height Height of the image in pixels
-     * @param density Density factor for rendering
+     * @param iconRenderProperties Properties for rendering the icon
      * @param content The Composable content to render
      * @return A hash value representing the current state of the composable content
      */
     @Composable
     fun calculateContentHash(
-        width: Int = 200,
-        height: Int = 200,
-        density: Float = 2f,
+        iconRenderProperties: IconRenderProperties,
         content: @Composable () -> Unit
     ): Long {
         // Render the composable to PNG bytes
-        val pngBytes = renderComposableToPngBytes(width, height, density, content)
+        val pngBytes = renderComposableToPngBytes(iconRenderProperties, content)
 
         // Calculate CRC32 hash of the PNG bytes
         val crc = CRC32()

--- a/src/commonMain/kotlin/com/kdroid/composetray/utils/IconRenderProperties.kt
+++ b/src/commonMain/kotlin/com/kdroid/composetray/utils/IconRenderProperties.kt
@@ -1,0 +1,82 @@
+package com.kdroid.composetray.utils
+
+import androidx.compose.ui.unit.Density
+import io.github.kdroidfilter.platformtools.OperatingSystem
+import io.github.kdroidfilter.platformtools.getOperatingSystem
+
+
+/**
+ * Properties for rendering a Composable icon.
+ *
+ * @property sceneWidth Width of the [androidx.compose.ui.ImageComposeScene] in pixels
+ * @property sceneHeight Height of the [androidx.compose.ui.ImageComposeScene] in pixels
+ * @property sceneDensity Density for [androidx.compose.ui.ImageComposeScene]
+ * @property targetWidth Width of the rendered icon in pixels
+ * @property targetHeight Height of the rendered icon in pixels
+ */
+data class IconRenderProperties(
+    val sceneWidth: Int = 192,
+    val sceneHeight: Int = 192,
+    val sceneDensity: Density = Density(2f),
+    val targetWidth: Int = 192,
+    val targetHeight: Int = 192
+) {
+    val requiresScaling = sceneWidth != targetWidth || sceneHeight != targetHeight
+
+    companion object {
+
+        /**
+         * Provides an [IconRenderProperties] configured for the current operating system.
+         *
+         * This method determines the rendering size based on the current operating system,
+         * defaulting to specific dimensions for Windows, macOS, and Linux. For unsupported operating
+         * systems, it defaults to the provided scene width and height.
+         *
+         * @param sceneWidth Width of the [androidx.compose.ui.ImageComposeScene] in pixels.
+         * @param sceneHeight Height of the [androidx.compose.ui.ImageComposeScene] in pixels.
+         * @param density Density of the [androidx.compose.ui.ImageComposeScene].
+         * @return An instance of [IconRenderProperties] with the appropriate target width and height
+         *         based on the operating system.
+         */
+        fun forCurrentOperatingSystem(
+            sceneWidth: Int = 192,
+            sceneHeight: Int = 192,
+            density: Density = Density(2f)
+        ): IconRenderProperties {
+            val (targetWidth, targetHeight) = when (getOperatingSystem()) {
+                OperatingSystem.WINDOWS -> 32 to 32
+                OperatingSystem.MACOS -> 44 to 44
+                OperatingSystem.LINUX -> 24 to 24
+                else -> sceneWidth to sceneHeight
+            }
+
+            return IconRenderProperties(
+                sceneWidth = sceneWidth,
+                sceneHeight = sceneHeight,
+                sceneDensity = density,
+                targetWidth = targetWidth,
+                targetHeight = targetHeight
+            )
+        }
+
+        /**
+         * Provides an [IconRenderProperties] configured with settings that don't force icon scaling and aliasing.
+         *
+         * @param sceneWidth Width of the [androidx.compose.ui.ImageComposeScene] in pixels.
+         * @param sceneHeight Height of the [androidx.compose.ui.ImageComposeScene] in pixels.
+         * @param density Density of the [androidx.compose.ui.ImageComposeScene].
+         * @return An instance of [IconRenderProperties] with the appropriate target width and height based on the operating system.
+         */
+        fun withoutScalingAndAliasing(
+            sceneWidth: Int = 192,
+            sceneHeight: Int = 192,
+            density: Density = Density(2f)
+        ) = IconRenderProperties(
+            sceneWidth = sceneWidth,
+            sceneHeight = sceneHeight,
+            sceneDensity = density,
+            targetWidth = sceneWidth,
+            targetHeight = sceneHeight
+        )
+    }
+}


### PR DESCRIPTION
- Icon render scene properties now encapsulated in `IconRenderProperties` and exposed to the `Tray()` function.
- `IconRenderProperties` allows to specify icon target size and by default uses a platform specific size.
- If icon target size is not equal to render scene size icon will be scaled with aliasing (see `renderComposableToPngBytes()`).
Example from Windows (before and after): ![image](https://github.com/user-attachments/assets/5ed79f77-2405-446d-8560-6f8fb7849ff8)

Also replaced `Color.White` with `Color.Unspecified` across the examples to prevent icon tinting at all.
