### PR TITLE
Fix Windows tray updates on separate thread

### DIFF
--- a/src/commonMain/kotlin/com/kdroid/composetray/lib/windows/WindowsTrayManager.kt
+++ b/src/commonMain/kotlin/com/kdroid/composetray/lib/windows/WindowsTrayManager.kt
@@ -145,7 +145,11 @@ internal class WindowsTrayManager(
                     task = updateQueue.poll()
                 }
 
-                if (trayLib.tray_loop(1) != 0) break
+                // Non blocking message loop so queued updates can be processed
+                if (trayLib.tray_loop(0) != 0) break
+
+                // Small sleep to avoid busy looping
+                Thread.sleep(16)
             }
         } catch (e: Exception) {
             e.printStackTrace()


### PR DESCRIPTION
## Summary
- ensure Windows tray updates happen on the tray thread
- queue update requests and process them inside the tray loop

## Testing
- `./gradlew build`

