### PR TITLE
Fix Duplicate Class Implementation Warning on macOS Tray() Initialization

### DIFF
--- a/src/commonMain/kotlin/com/kdroid/composetray/lib/mac/MacOSMenuBarThemeDetector.kt
+++ b/src/commonMain/kotlin/com/kdroid/composetray/lib/mac/MacOSMenuBarThemeDetector.kt
@@ -11,7 +11,7 @@ import com.kdroid.composetray.lib.mac.MacTrayManager.MacTrayLibrary
 
 object MacOSMenuBarThemeDetector {
 
-    private val trayLib: MacTrayLibrary = Native.load("MacTray", MacTrayLibrary::class.java)
+    private val trayLib: MacTrayLibrary = MacTrayLoader.lib
 
     private val listeners: MutableSet<Consumer<Boolean>> = ConcurrentHashMap.newKeySet()
 

--- a/src/commonMain/kotlin/com/kdroid/composetray/lib/mac/MacTrayLoader.kt
+++ b/src/commonMain/kotlin/com/kdroid/composetray/lib/mac/MacTrayLoader.kt
@@ -1,0 +1,21 @@
+package com.kdroid.composetray.lib.mac
+
+import com.kdroid.composetray.lib.mac.MacTrayManager.MacTrayLibrary
+import com.sun.jna.Native
+
+/**
+ * Centralized, process-wide loader for the macOS native tray library.
+ *
+ * JNA will otherwise extract the bundled dylib to a temporary, uniquely-named file
+ * for each independent load request. Loading the same library multiple times can
+ * lead to duplicate Objective‑C/Swift class definitions (e.g., MenuDelegate),
+ * causing warnings and potential crashes on macOS.
+ *
+ * By exposing a single lazy-loaded instance, we ensure the library is loaded
+ * exactly once per process and all callers reuse the same handle.
+ */
+internal object MacTrayLoader {
+    val lib: MacTrayLibrary by lazy(LazyThreadSafetyMode.SYNCHRONIZED) {
+        Native.load("MacTray", MacTrayLibrary::class.java)
+    }
+}

--- a/src/commonMain/kotlin/com/kdroid/composetray/lib/mac/MacTrayManager.kt
+++ b/src/commonMain/kotlin/com/kdroid/composetray/lib/mac/MacTrayManager.kt
@@ -21,7 +21,7 @@ internal class MacTrayManager(
     private var tooltip: String = "",
     onLeftClick: (() -> Unit)? = null
 ) {
-    private val trayLib: MacTrayLibrary = Native.load("MacTray", MacTrayLibrary::class.java)
+    private val trayLib: MacTrayLibrary = MacTrayLoader.lib
     private var tray: MacTray? = null
     private val menuItems: MutableList<MenuItem> = mutableListOf()
     private val running = AtomicBoolean(false)

--- a/src/commonMain/kotlin/com/kdroid/composetray/utils/TrayPosition.kt
+++ b/src/commonMain/kotlin/com/kdroid/composetray/utils/TrayPosition.kt
@@ -3,6 +3,7 @@ package com.kdroid.composetray.utils
 import com.kdroid.composetray.lib.windows.WindowsNativeTrayLibrary
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.WindowPosition
+import com.kdroid.composetray.lib.mac.MacTrayLoader
 import com.kdroid.composetray.lib.mac.MacTrayManager
 import com.sun.jna.Native
 import com.sun.jna.ptr.IntByReference
@@ -134,8 +135,7 @@ fun getTrayPosition(): TrayPosition {
             return getWindowsTrayPosition(trayLib.tray_get_notification_icons_region())
         }
         OperatingSystem.MACOS -> {
-            val lib: MacTrayManager.MacTrayLibrary =
-                Native.load("MacTray", MacTrayManager.MacTrayLibrary::class.java)
+            val lib = MacTrayLoader.lib
             return getMacTrayPosition(lib.tray_get_status_item_region())
         }
         OperatingSystem.LINUX -> {
@@ -355,8 +355,7 @@ internal fun getMacTrayPosition(nativeResult: String?): TrayPosition = when (nat
 internal fun getStatusItemXYForMac(): Pair<Int, Int> {
     val xRef = IntByReference()
     val yRef = IntByReference()
-    val lib: MacTrayManager.MacTrayLibrary =
-        Native.load("MacTray", MacTrayManager.MacTrayLibrary::class.java)
+    val lib = MacTrayLoader.lib
 
     val precise = lib.tray_get_status_item_position(xRef, yRef) != 0
     return xRef.value to yRef.value    // si !precise, valeurs = (0,0)


### PR DESCRIPTION
### Description

- Replaced direct `Native.load` calls with `MacTrayLoader.lib` to centralize and standardize Mac tray library loading.

