### PR TITLE
fix(macOS): write tray state to writable tmp and namespace by app ID to avoid conflicts

### DIFF
--- a/src/commonMain/kotlin/com/kdroid/composetray/utils/AppId.kt
+++ b/src/commonMain/kotlin/com/kdroid/composetray/utils/AppId.kt
@@ -1,0 +1,37 @@
+package com.kdroid.composetray.utils
+
+/**
+ * Provides a unique, stable application identifier to namespace shared resources
+ * (temp files, locks, properties) and avoid conflicts when multiple apps use
+ * this library on the same machine.
+ *
+ * Resolution order (first non-empty wins):
+ * 1) System property "compose.native.tray.appId"
+ * 2) Environment variable "COMPOSE_NATIVE_TRAY_APP_ID"
+ * 3) Main class from system property "sun.java.command" (first token)
+ * 4) Fallback to "ComposeNativeTrayApp"
+ */
+object AppIdProvider {
+    private val cached by lazy { computeAppId() }
+
+    fun appId(): String = cached
+
+    private fun computeAppId(): String {
+        val sunCmd = System.getProperty("sun.java.command")?.trim().orEmpty()
+        println("AppIdProvider: sunCmd: $sunCmd")
+
+        if (sunCmd.isNotEmpty()) {
+            val firstToken = sunCmd.split(" ", limit = 2).firstOrNull().orEmpty()
+            if (firstToken.isNotEmpty()) return sanitize(firstToken)
+        }
+
+        // Fallback
+        return "ComposeNativeTrayApp"
+    }
+
+    private fun sanitize(raw: String): String {
+        // Replace non-alphanumeric/._- with underscore; trim length if excessively long
+        val cleaned = raw.replace(Regex("[^A-Za-z0-9._-]"), "_")
+        return cleaned.take(128).ifEmpty { "ComposeNativeTrayApp" }
+    }
+}

--- a/src/commonMain/kotlin/com/kdroid/composetray/utils/SingleInstanceManager.kt
+++ b/src/commonMain/kotlin/com/kdroid/composetray/utils/SingleInstanceManager.kt
@@ -166,7 +166,7 @@ object SingleInstanceManager {
     }
 
     private fun getAppIdentifier(): String {
-        val callerClassName = Thread.currentThread().stackTrace[3].className
-        return callerClassName.replace(".", "_")
+        // Use unified app ID provider to avoid cross-app conflicts and allow explicit override
+        return AppIdProvider.appId()
     }
 }


### PR DESCRIPTION
- Write tray_position.properties to a writable tmp path: {java.io.tmpdir}/ComposeNativeTray/<appId>/tray_position.properties to avoid read-only crashes (e.g., macOS app bundles).
- Introduce AppIdProvider to namespace files per app and prevent cross‑app conflicts.
    - Overrides: system property compose.native.tray.appId or env COMPOSE_NATIVE_TRAY_APP_ID.
- Update SingleInstanceManager to use the same app ID for lock/restore files.
- Keep backward-compatible reads (legacy CWD and old tmp without app ID).
- Make I/O best-effort (swallow exceptions) to prevent crashes on restrictive FS.
fix #245 