### PR TITLE
Refactor dialog positioning and transition animations in TrayApp

### DIFF
--- a/src/commonMain/kotlin/com/kdroid/composetray/tray/api/TrayApp.kt
+++ b/src/commonMain/kotlin/com/kdroid/composetray/tray/api/TrayApp.kt
@@ -68,7 +68,7 @@ private val defaultTrayAppExitTransition =
 
 private val defaultVerticalOffset = when (getOperatingSystem()) {
     WINDOWS -> -10
-    MACOS -> 30
+    MACOS -> 5
     else -> when (detectLinuxDesktopEnvironment()) {
         LinuxDesktopEnvironment.GNOME -> 10
         else -> 0

--- a/src/commonMain/kotlin/com/kdroid/composetray/tray/api/TrayApp.kt
+++ b/src/commonMain/kotlin/com/kdroid/composetray/tray/api/TrayApp.kt
@@ -707,7 +707,6 @@ private fun ApplicationScope.TrayAppImplLinux(
     menu: (TrayMenuBuilder.() -> Unit)?,
     content: @Composable DialogWindowScope.() -> Unit,
 ) {
-    val isKde = detectLinuxDesktopEnvironment() == LinuxDesktopEnvironment.KDE
     val trayAppState = state ?: rememberTrayAppState(
         initialWindowSize = windowSize ?: DpSize(300.dp, 200.dp),
         initiallyVisible = visibleOnStart,
@@ -742,7 +741,6 @@ private fun ApplicationScope.TrayAppImplLinux(
     }
 
     val dialogState = rememberDialogState(position = initialPositionForFirstFrame, size = currentWindowSize)
-    if (isKde) SideEffect { dialogState.position = initialPositionForFirstFrame }
     LaunchedEffect(currentWindowSize) { dialogState.size = currentWindowSize }
 
     // Visibility controller for exit-finish detection; content will NOT be disposed.

--- a/src/commonMain/kotlin/com/kdroid/composetray/tray/api/TrayApp.kt
+++ b/src/commonMain/kotlin/com/kdroid/composetray/tray/api/TrayApp.kt
@@ -55,7 +55,7 @@ private val defaultTrayAppEnterTransition =
             animationSpec = tween(250, easing = EaseInOut)
         ) + fadeIn(animationSpec = tween(200, easing = EaseInOut))
     else
-        fadeIn(animationSpec = tween(200, easing = EaseInOut))
+        fadeIn(animationSpec = tween(if (detectLinuxDesktopEnvironment() == LinuxDesktopEnvironment.KDE) 50 else 200, easing = EaseInOut))
 
 private val defaultTrayAppExitTransition =
     if (getOperatingSystem() == WINDOWS)
@@ -64,7 +64,7 @@ private val defaultTrayAppExitTransition =
             animationSpec = tween(250, easing = EaseInOut)
         ) + fadeOut(animationSpec = tween(200, easing = EaseInOut))
     else
-        fadeOut(animationSpec = tween(200, easing = EaseInOut))
+        fadeOut(animationSpec = tween(if (detectLinuxDesktopEnvironment() == LinuxDesktopEnvironment.KDE) 50 else 200, easing = EaseInOut))
 
 private val defaultVerticalOffset = when (getOperatingSystem()) {
     WINDOWS -> -10
@@ -781,10 +781,6 @@ private fun ApplicationScope.TrayAppImplLinux(
 
         if (isVisible) {
             if (!shouldShowWindow) {
-                val w = currentWindowSize.width.value.toInt()
-                val h = currentWindowSize.height.value.toInt()
-                dialogState.position =
-                    getTrayWindowPositionForInstance(instanceKey, w, h, horizontalOffset, verticalOffset)
                 shouldShowWindow = true
                 lastShownAt = System.currentTimeMillis()
             }

--- a/src/commonMain/kotlin/com/kdroid/composetray/tray/api/TrayApp.kt
+++ b/src/commonMain/kotlin/com/kdroid/composetray/tray/api/TrayApp.kt
@@ -741,7 +741,6 @@ private fun ApplicationScope.TrayAppImplLinux(
     }
 
     val dialogState = rememberDialogState(position = initialPositionForFirstFrame, size = currentWindowSize)
-    SideEffect { dialogState.position = initialPositionForFirstFrame }
     LaunchedEffect(currentWindowSize) { dialogState.size = currentWindowSize }
 
     // Visibility controller for exit-finish detection; content will NOT be disposed.

--- a/src/commonMain/kotlin/com/kdroid/composetray/tray/api/TrayApp.kt
+++ b/src/commonMain/kotlin/com/kdroid/composetray/tray/api/TrayApp.kt
@@ -28,9 +28,11 @@ import com.kdroid.composetray.lib.mac.MacOutsideClickWatcher
 import com.kdroid.composetray.lib.windows.WindowsOutsideClickWatcher
 import com.kdroid.composetray.menu.api.TrayMenuBuilder
 import com.kdroid.composetray.utils.*
+import io.github.kdroidfilter.platformtools.LinuxDesktopEnvironment
 import io.github.kdroidfilter.platformtools.OperatingSystem
 import io.github.kdroidfilter.platformtools.OperatingSystem.MACOS
 import io.github.kdroidfilter.platformtools.OperatingSystem.WINDOWS
+import io.github.kdroidfilter.platformtools.detectLinuxDesktopEnvironment
 import io.github.kdroidfilter.platformtools.getOperatingSystem
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -67,7 +69,10 @@ private val defaultTrayAppExitTransition =
 private val defaultVerticalOffset = when (getOperatingSystem()) {
     WINDOWS -> -10
     MACOS -> 30
-    else -> 0
+    else -> when (detectLinuxDesktopEnvironment()) {
+        LinuxDesktopEnvironment.GNOME -> 25
+        else -> 0
+    }
 }
 
 // --------------------- Public API (overloads) ---------------------

--- a/src/commonMain/kotlin/com/kdroid/composetray/tray/api/TrayApp.kt
+++ b/src/commonMain/kotlin/com/kdroid/composetray/tray/api/TrayApp.kt
@@ -19,14 +19,8 @@ import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.graphics.painter.Painter
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.input.key.KeyEvent
-import androidx.compose.ui.layout.*
-import androidx.compose.ui.unit.Constraints
 import androidx.compose.ui.unit.DpSize
-import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.util.fastForEach
-import androidx.compose.ui.util.fastMap
-import androidx.compose.ui.util.fastMaxOfOrDefault
 import androidx.compose.ui.window.*
 import com.kdroid.composetray.lib.linux.LinuxOutsideClickWatcher
 import com.kdroid.composetray.lib.mac.MacOSWindowManager
@@ -49,7 +43,6 @@ import org.jetbrains.compose.resources.painterResource
 import java.awt.EventQueue.invokeLater
 import java.awt.event.WindowEvent
 import java.awt.event.WindowFocusListener
-import kotlin.math.max
 
 // --------------------- Public API (defaults) ---------------------
 

--- a/src/commonMain/kotlin/com/kdroid/composetray/tray/api/TrayApp.kt
+++ b/src/commonMain/kotlin/com/kdroid/composetray/tray/api/TrayApp.kt
@@ -41,27 +41,29 @@ import java.awt.EventQueue.invokeLater
 import java.awt.event.WindowEvent
 import java.awt.event.WindowFocusListener
 
+// --------------------- Public API (defaults) ---------------------
+
+val defaultTrayAppEnterTransition =
+    if (getOperatingSystem() == WINDOWS)
+        slideInVertically(
+            initialOffsetY = { fullHeight -> fullHeight },
+            animationSpec = tween(250, easing = EaseInOut)
+        ) + fadeIn(animationSpec = tween(200, easing = EaseInOut))
+    else
+        fadeIn(animationSpec = tween(200, easing = EaseInOut))
+
+val defaultTrayAppExitTransition =
+    if (getOperatingSystem() == WINDOWS)
+        slideOutVertically(
+            targetOffsetY = { fullHeight -> fullHeight },
+            animationSpec = tween(250, easing = EaseInOut)
+        ) + fadeOut(animationSpec = tween(200, easing = EaseInOut))
+    else
+        fadeOut(animationSpec = tween(200, easing = EaseInOut))
+
+
+val defaultVerticalOffset = if (getOperatingSystem() == WINDOWS) -10 else 0
 // --------------------- Public API (overloads) ---------------------
-
-val defaultTrayAppEnterTransition = if (getOperatingSystem() == WINDOWS) slideInVertically(
-    initialOffsetY = { fullHeight -> fullHeight },
-    animationSpec = tween(250, easing = EaseInOut)
-) + fadeIn(animationSpec = tween(200, easing = EaseInOut)) else fadeIn(
-    animationSpec = tween(
-        200,
-        easing = EaseInOut
-    )
-)
-
-val defaultTrayAppExitTransition = if (getOperatingSystem() == WINDOWS) slideOutVertically(
-    targetOffsetY = { fullHeight -> fullHeight },
-    animationSpec = tween(250, easing = EaseInOut)
-) + fadeOut(animationSpec = tween(200, easing = EaseInOut)) else fadeOut(
-    animationSpec = tween(
-        200,
-        easing = EaseInOut
-    )
-)
 
 @ExperimentalTrayAppApi
 @Composable
@@ -80,6 +82,8 @@ fun ApplicationScope.TrayApp(
     windowIcon: Painter? = null,
     undecorated: Boolean = true,
     resizable: Boolean = false,
+    horizontalOffset: Int = 0,
+    verticalOffset: Int = defaultVerticalOffset,
     onPreviewKeyEvent: (KeyEvent) -> Boolean = { false },
     onKeyEvent: (KeyEvent) -> Boolean = { false },
     menu: (TrayMenuBuilder.() -> Unit)? = null,
@@ -109,6 +113,8 @@ fun ApplicationScope.TrayApp(
         windowIcon = windowIcon,
         undecorated = undecorated,
         resizable = resizable,
+        horizontalOffset = horizontalOffset,
+        verticalOffset = verticalOffset,
         onPreviewKeyEvent = onPreviewKeyEvent,
         onKeyEvent = onKeyEvent,
         menu = menu,
@@ -132,6 +138,8 @@ fun ApplicationScope.TrayApp(
     windowIcon: Painter? = null,
     undecorated: Boolean = true,
     resizable: Boolean = false,
+    horizontalOffset: Int = 0,
+    verticalOffset: Int = defaultVerticalOffset,
     onPreviewKeyEvent: (KeyEvent) -> Boolean = { false },
     onKeyEvent: (KeyEvent) -> Boolean = { false },
     menu: (TrayMenuBuilder.() -> Unit)? = null,
@@ -154,6 +162,8 @@ fun ApplicationScope.TrayApp(
         windowIcon = windowIcon,
         undecorated = undecorated,
         resizable = resizable,
+        horizontalOffset = horizontalOffset,
+        verticalOffset = verticalOffset,
         onPreviewKeyEvent = onPreviewKeyEvent,
         onKeyEvent = onKeyEvent,
         menu = menu,
@@ -180,6 +190,8 @@ fun ApplicationScope.TrayApp(
     windowIcon: Painter? = null,
     undecorated: Boolean = true,
     resizable: Boolean = false,
+    horizontalOffset: Int = 0,
+    verticalOffset: Int = defaultVerticalOffset,
     onPreviewKeyEvent: (KeyEvent) -> Boolean = { false },
     onKeyEvent: (KeyEvent) -> Boolean = { false },
     menu: (TrayMenuBuilder.() -> Unit)? = null,
@@ -200,6 +212,8 @@ fun ApplicationScope.TrayApp(
             windowIcon = windowIcon,
             undecorated = undecorated,
             resizable = resizable,
+            horizontalOffset = horizontalOffset,
+            verticalOffset = verticalOffset,
             onPreviewKeyEvent = onPreviewKeyEvent,
             onKeyEvent = onKeyEvent,
             menu = menu,
@@ -221,6 +235,8 @@ fun ApplicationScope.TrayApp(
             windowIcon = windowIcon,
             undecorated = undecorated,
             resizable = resizable,
+            horizontalOffset = horizontalOffset,
+            verticalOffset = verticalOffset,
             onPreviewKeyEvent = onPreviewKeyEvent,
             onKeyEvent = onKeyEvent,
             menu = menu,
@@ -245,6 +261,8 @@ fun ApplicationScope.TrayApp(
     windowIcon: Painter? = null,
     undecorated: Boolean = true,
     resizable: Boolean = false,
+    horizontalOffset: Int = 0,
+    verticalOffset: Int = defaultVerticalOffset,
     onPreviewKeyEvent: (KeyEvent) -> Boolean = { false },
     onKeyEvent: (KeyEvent) -> Boolean = { false },
     menu: (TrayMenuBuilder.() -> Unit)? = null,
@@ -264,6 +282,8 @@ fun ApplicationScope.TrayApp(
         windowIcon = windowIcon,
         undecorated = undecorated,
         resizable = resizable,
+        horizontalOffset = horizontalOffset,
+        verticalOffset = verticalOffset,
         menu = menu,
         content = content,
     )
@@ -287,6 +307,8 @@ fun ApplicationScope.TrayApp(
     windowIcon: Painter? = null,
     undecorated: Boolean = true,
     resizable: Boolean = false,
+    horizontalOffset: Int = 0,
+    verticalOffset: Int = defaultVerticalOffset,
     onPreviewKeyEvent: (KeyEvent) -> Boolean = { false },
     onKeyEvent: (KeyEvent) -> Boolean = { false },
     menu: (TrayMenuBuilder.() -> Unit)? = null,
@@ -307,6 +329,8 @@ fun ApplicationScope.TrayApp(
             windowIcon = windowIcon,
             undecorated = undecorated,
             resizable = resizable,
+            horizontalOffset = horizontalOffset,
+            verticalOffset = verticalOffset,
             onPreviewKeyEvent = onPreviewKeyEvent,
             onKeyEvent = onKeyEvent,
             menu = menu,
@@ -328,6 +352,8 @@ fun ApplicationScope.TrayApp(
             windowIcon = windowIcon,
             undecorated = undecorated,
             resizable = resizable,
+            horizontalOffset = horizontalOffset,
+            verticalOffset = verticalOffset,
             onPreviewKeyEvent = onPreviewKeyEvent,
             onKeyEvent = onKeyEvent,
             menu = menu,
@@ -354,6 +380,8 @@ fun ApplicationScope.TrayApp(
     windowIcon: Painter? = null,
     undecorated: Boolean = true,
     resizable: Boolean = false,
+    horizontalOffset: Int = 0,
+    verticalOffset: Int = defaultVerticalOffset,
     onPreviewKeyEvent: (KeyEvent) -> Boolean = { false },
     onKeyEvent: (KeyEvent) -> Boolean = { false },
     menu: (TrayMenuBuilder.() -> Unit)? = null,
@@ -363,13 +391,14 @@ fun ApplicationScope.TrayApp(
         OperatingSystem.LINUX -> TrayAppImplLinux(
             iconContent, iconRenderProperties, tooltip, state, windowSize,
             visibleOnStart, enterTransition, exitTransition, transparent, windowsTitle,
-            windowIcon, undecorated, resizable, onPreviewKeyEvent, onKeyEvent, menu, content
+            windowIcon, undecorated, resizable, horizontalOffset, verticalOffset,
+            onPreviewKeyEvent, onKeyEvent, menu, content
         )
-
         else -> TrayAppImplOriginal(
             iconContent, iconRenderProperties, tooltip, state, windowSize,
             visibleOnStart, enterTransition, exitTransition, transparent, windowsTitle,
-            windowIcon, undecorated, resizable, onPreviewKeyEvent, onKeyEvent, menu, content
+            windowIcon, undecorated, resizable, horizontalOffset, verticalOffset,
+            onPreviewKeyEvent, onKeyEvent, menu, content
         )
     }
 }
@@ -391,6 +420,8 @@ private fun ApplicationScope.TrayAppImplOriginal(
     windowIcon: Painter?,
     undecorated: Boolean,
     resizable: Boolean,
+    horizontalOffset: Int,
+    verticalOffset: Int,
     onPreviewKeyEvent: (KeyEvent) -> Boolean,
     onKeyEvent: (KeyEvent) -> Boolean,
     menu: (TrayMenuBuilder.() -> Unit)?,
@@ -485,7 +516,8 @@ private fun ApplicationScope.TrayAppImplOriginal(
                 val deadline = System.currentTimeMillis() + 3000
                 while (position is WindowPosition.PlatformDefault && System.currentTimeMillis() < deadline) {
                     position = getTrayWindowPositionForInstance(
-                        tray.instanceKey(), widthPx, heightPx
+                        tray.instanceKey(), widthPx, heightPx,
+                        horizontalOffset, verticalOffset
                     )
                     delay(150)
                 }
@@ -623,6 +655,8 @@ private fun ApplicationScope.TrayAppImplLinux(
     windowIcon: Painter?,
     undecorated: Boolean,
     resizable: Boolean,
+    horizontalOffset: Int,
+    verticalOffset: Int,
     onPreviewKeyEvent: (KeyEvent) -> Boolean,
     onKeyEvent: (KeyEvent) -> Boolean,
     menu: (TrayMenuBuilder.() -> Unit)?,
@@ -656,10 +690,10 @@ private fun ApplicationScope.TrayAppImplLinux(
     val minVisibleDurationMs = 350L
     val minHiddenDurationMs = 250L
 
-    val initialPositionForFirstFrame = remember(instanceKey, currentWindowSize) {
+    val initialPositionForFirstFrame = remember(instanceKey, currentWindowSize, horizontalOffset, verticalOffset) {
         val w = currentWindowSize.width.value.toInt()
         val h = currentWindowSize.height.value.toInt()
-        getTrayWindowPositionForInstance(instanceKey, w, h)
+        getTrayWindowPositionForInstance(instanceKey, w, h, horizontalOffset, verticalOffset)
     }
 
     val dialogState = rememberDialogState(position = initialPositionForFirstFrame, size = currentWindowSize)
@@ -692,7 +726,7 @@ private fun ApplicationScope.TrayAppImplLinux(
         } else if (now - lastHiddenAt >= minHiddenDurationMs) {
             val w = currentWindowSize.width.value.toInt()
             val h = currentWindowSize.height.value.toInt()
-            dialogState.position = getTrayWindowPositionForInstance(instanceKey, w, h)
+            dialogState.position = getTrayWindowPositionForInstance(instanceKey, w, h, horizontalOffset, verticalOffset)
             trayAppState.show()
         }
     }
@@ -705,7 +739,7 @@ private fun ApplicationScope.TrayAppImplLinux(
             if (!shouldShowWindow) {
                 val w = currentWindowSize.width.value.toInt()
                 val h = currentWindowSize.height.value.toInt()
-                dialogState.position = getTrayWindowPositionForInstance(instanceKey, w, h)
+                dialogState.position = getTrayWindowPositionForInstance(instanceKey, w, h, horizontalOffset, verticalOffset)
                 shouldShowWindow = true
                 lastShownAt = System.currentTimeMillis()
             }
@@ -719,12 +753,12 @@ private fun ApplicationScope.TrayAppImplLinux(
         }
     }
 
-    // Re-anchor when visible and size changes
-    LaunchedEffect(currentWindowSize, shouldShowWindow) {
+    // Re-anchor when visible and size/offset changes
+    LaunchedEffect(currentWindowSize, horizontalOffset, verticalOffset, shouldShowWindow) {
         if (shouldShowWindow) {
             val w = currentWindowSize.width.value.toInt()
             val h = currentWindowSize.height.value.toInt()
-            dialogState.position = getTrayWindowPositionForInstance(instanceKey, w, h)
+            dialogState.position = getTrayWindowPositionForInstance(instanceKey, w, h, horizontalOffset, verticalOffset)
         }
     }
 
@@ -754,7 +788,7 @@ private fun ApplicationScope.TrayAppImplLinux(
             runCatching {
                 val w = currentWindowSize.width.value.toInt()
                 val h = currentWindowSize.height.value.toInt()
-                dialogState.position = getTrayWindowPositionForInstance(instanceKey, w, h)
+                dialogState.position = getTrayWindowPositionForInstance(instanceKey, w, h, horizontalOffset, verticalOffset)
             }
 
             val linuxWatcher = if (dismissMode == TrayWindowDismissMode.AUTO) {

--- a/src/commonMain/kotlin/com/kdroid/composetray/tray/api/TrayApp.kt
+++ b/src/commonMain/kotlin/com/kdroid/composetray/tray/api/TrayApp.kt
@@ -2,16 +2,19 @@
 
 package com.kdroid.composetray.tray.api
 
-import androidx.compose.animation.core.AnimationSpec
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.EnterTransition
+import androidx.compose.animation.ExitTransition
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
 import androidx.compose.animation.core.EaseInOut
-import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.core.MutableTransitionState
 import androidx.compose.animation.core.tween
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.*
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.graphics.painter.Painter
@@ -21,9 +24,9 @@ import androidx.compose.ui.unit.DpSize
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.ApplicationScope
 import androidx.compose.ui.window.DialogWindow
+import androidx.compose.ui.window.DialogWindowScope
 import androidx.compose.ui.window.WindowPosition
 import androidx.compose.ui.window.rememberDialogState
-import androidx.compose.ui.window.DialogWindowScope
 import com.kdroid.composetray.lib.linux.LinuxOutsideClickWatcher
 import com.kdroid.composetray.lib.mac.MacOSWindowManager
 import com.kdroid.composetray.lib.mac.MacOutsideClickWatcher
@@ -38,6 +41,7 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import org.jetbrains.compose.resources.DrawableResource
 import org.jetbrains.compose.resources.painterResource
@@ -45,12 +49,8 @@ import java.awt.EventQueue.invokeLater
 import java.awt.event.WindowEvent
 import java.awt.event.WindowFocusListener
 
+// --------------------- Public API (overloads) ---------------------
 
-/**
- * Creates a tray-based desktop application with support for customizable icons, tooltips, menus,
- * and composable content. The application integrates with the system's tray or menu bar and
- * supports optional window functionality.
- */
 @ExperimentalTrayAppApi
 @Composable
 fun ApplicationScope.TrayApp(
@@ -61,8 +61,8 @@ fun ApplicationScope.TrayApp(
     state: TrayAppState? = null,
     windowSize: DpSize? = null,
     visibleOnStart: Boolean = false,
-    fadeDurationMs: Int = 200,
-    animationSpec: AnimationSpec<Float> = tween(durationMillis = fadeDurationMs, easing = EaseInOut),
+    enterTransition: EnterTransition = fadeIn(animationSpec = tween(200, easing = EaseInOut)),
+    exitTransition: ExitTransition = fadeOut(animationSpec = tween(200, easing = EaseInOut)),
     transparent: Boolean = true,
     windowsTitle: String = "",
     windowIcon: Painter? = null,
@@ -90,8 +90,8 @@ fun ApplicationScope.TrayApp(
         state = state,
         windowSize = windowSize,
         visibleOnStart = visibleOnStart,
-        fadeDurationMs = fadeDurationMs,
-        animationSpec = animationSpec,
+        enterTransition = enterTransition,
+        exitTransition = exitTransition,
         transparent = transparent,
         windowsTitle = windowsTitle,
         windowIcon = windowIcon,
@@ -113,8 +113,8 @@ fun ApplicationScope.TrayApp(
     state: TrayAppState? = null,
     windowSize: DpSize? = null,
     visibleOnStart: Boolean = false,
-    fadeDurationMs: Int = 200,
-    animationSpec: AnimationSpec<Float> = tween(durationMillis = fadeDurationMs, easing = EaseInOut),
+    enterTransition: EnterTransition = fadeIn(animationSpec = tween(200, easing = EaseInOut)),
+    exitTransition: ExitTransition = fadeOut(animationSpec = tween(200, easing = EaseInOut)),
     transparent: Boolean = true,
     windowsTitle: String = "",
     windowIcon: Painter? = null,
@@ -135,8 +135,8 @@ fun ApplicationScope.TrayApp(
         state = state,
         windowSize = windowSize,
         visibleOnStart = visibleOnStart,
-        fadeDurationMs = fadeDurationMs,
-        animationSpec = animationSpec,
+        enterTransition = enterTransition,
+        exitTransition = exitTransition,
         transparent = transparent,
         windowsTitle = windowsTitle,
         windowIcon = windowIcon,
@@ -149,7 +149,7 @@ fun ApplicationScope.TrayApp(
     )
 }
 
-/** Platform-overloaded API (Painter for Windows, ImageVector for macOS/Linux) */
+/** Painter on Windows, ImageVector on macOS/Linux */
 @ExperimentalTrayAppApi
 @Composable
 fun ApplicationScope.TrayApp(
@@ -161,8 +161,8 @@ fun ApplicationScope.TrayApp(
     state: TrayAppState? = null,
     windowSize: DpSize? = null,
     visibleOnStart: Boolean = false,
-    fadeDurationMs: Int = 200,
-    animationSpec: AnimationSpec<Float> = tween(durationMillis = fadeDurationMs, easing = EaseInOut),
+    enterTransition: EnterTransition = fadeIn(animationSpec = tween(200, easing = EaseInOut)),
+    exitTransition: ExitTransition = fadeOut(animationSpec = tween(200, easing = EaseInOut)),
     transparent: Boolean = true,
     windowsTitle: String = "",
     windowIcon: Painter? = null,
@@ -181,8 +181,8 @@ fun ApplicationScope.TrayApp(
             state = state,
             windowSize = windowSize,
             visibleOnStart = visibleOnStart,
-            fadeDurationMs = fadeDurationMs,
-            animationSpec = animationSpec,
+            enterTransition = enterTransition,
+            exitTransition = exitTransition,
             transparent = transparent,
             windowsTitle = windowsTitle,
             windowIcon = windowIcon,
@@ -202,8 +202,8 @@ fun ApplicationScope.TrayApp(
             state = state,
             windowSize = windowSize,
             visibleOnStart = visibleOnStart,
-            fadeDurationMs = fadeDurationMs,
-            animationSpec = animationSpec,
+            enterTransition = enterTransition,
+            exitTransition = exitTransition,
             transparent = transparent,
             windowsTitle = windowsTitle,
             windowIcon = windowIcon,
@@ -226,8 +226,8 @@ fun ApplicationScope.TrayApp(
     state: TrayAppState? = null,
     windowSize: DpSize? = null,
     visibleOnStart: Boolean = false,
-    fadeDurationMs: Int = 200,
-    animationSpec: AnimationSpec<Float> = tween(durationMillis = fadeDurationMs, easing = EaseInOut),
+    enterTransition: EnterTransition = fadeIn(animationSpec = tween(200, easing = EaseInOut)),
+    exitTransition: ExitTransition = fadeOut(animationSpec = tween(200, easing = EaseInOut)),
     transparent: Boolean = true,
     windowsTitle: String = "",
     windowIcon: Painter? = null,
@@ -245,8 +245,8 @@ fun ApplicationScope.TrayApp(
         state = state,
         windowSize = windowSize,
         visibleOnStart = visibleOnStart,
-        fadeDurationMs = fadeDurationMs,
-        animationSpec = animationSpec,
+        enterTransition = enterTransition,
+        exitTransition = exitTransition,
         transparent = transparent,
         windowsTitle = windowsTitle,
         windowIcon = windowIcon,
@@ -268,8 +268,8 @@ fun ApplicationScope.TrayApp(
     state: TrayAppState? = null,
     windowSize: DpSize? = null,
     visibleOnStart: Boolean = false,
-    fadeDurationMs: Int = 200,
-    animationSpec: AnimationSpec<Float> = tween(durationMillis = fadeDurationMs, easing = EaseInOut),
+    enterTransition: EnterTransition = fadeIn(animationSpec = tween(200, easing = EaseInOut)),
+    exitTransition: ExitTransition = fadeOut(animationSpec = tween(200, easing = EaseInOut)),
     transparent: Boolean = true,
     windowsTitle: String = "",
     windowIcon: Painter? = null,
@@ -288,8 +288,8 @@ fun ApplicationScope.TrayApp(
             state = state,
             windowSize = windowSize,
             visibleOnStart = visibleOnStart,
-            fadeDurationMs = fadeDurationMs,
-            animationSpec = animationSpec,
+            enterTransition = enterTransition,
+            exitTransition = exitTransition,
             transparent = transparent,
             windowsTitle = windowsTitle,
             windowIcon = windowIcon,
@@ -309,8 +309,8 @@ fun ApplicationScope.TrayApp(
             state = state,
             windowSize = windowSize,
             visibleOnStart = visibleOnStart,
-            fadeDurationMs = fadeDurationMs,
-            animationSpec = animationSpec,
+            enterTransition = enterTransition,
+            exitTransition = exitTransition,
             transparent = transparent,
             windowsTitle = windowsTitle,
             windowIcon = windowIcon,
@@ -324,7 +324,7 @@ fun ApplicationScope.TrayApp(
     }
 }
 
-// --------------------- Core (routes per platform) ---------------------
+// --------------------- Core router ---------------------
 
 @ExperimentalTrayAppApi
 @Composable
@@ -335,8 +335,8 @@ fun ApplicationScope.TrayApp(
     state: TrayAppState? = null,
     windowSize: DpSize? = null,
     visibleOnStart: Boolean = false,
-    fadeDurationMs: Int = 200,
-    animationSpec: AnimationSpec<Float> = tween(durationMillis = fadeDurationMs, easing = EaseInOut),
+    enterTransition: EnterTransition = fadeIn(animationSpec = tween(200, easing = EaseInOut)),
+    exitTransition: ExitTransition = fadeOut(animationSpec = tween(200, easing = EaseInOut)),
     transparent: Boolean = true,
     windowsTitle: String = "",
     windowIcon: Painter? = null,
@@ -350,16 +350,18 @@ fun ApplicationScope.TrayApp(
     when (getOperatingSystem()) {
         OperatingSystem.LINUX -> TrayAppImplLinux(
             iconContent, iconRenderProperties, tooltip, state, windowSize,
-            visibleOnStart, fadeDurationMs, animationSpec, transparent, windowsTitle, windowIcon, undecorated, resizable, onPreviewKeyEvent, onKeyEvent, menu, content
+            visibleOnStart, enterTransition, exitTransition, transparent, windowsTitle,
+            windowIcon, undecorated, resizable, onPreviewKeyEvent, onKeyEvent, menu, content
         )
         else -> TrayAppImplOriginal(
             iconContent, iconRenderProperties, tooltip, state, windowSize,
-            visibleOnStart, fadeDurationMs, animationSpec, transparent, windowsTitle, windowIcon, undecorated, resizable, onPreviewKeyEvent, onKeyEvent, menu, content
+            visibleOnStart, enterTransition, exitTransition, transparent, windowsTitle,
+            windowIcon, undecorated, resizable, onPreviewKeyEvent, onKeyEvent, menu, content
         )
     }
 }
 
-// --------------------- Impl: Original (macOS/Windows) ---------------------
+// --------------------- Impl: macOS/Windows ---------------------
 
 @Composable
 private fun ApplicationScope.TrayAppImplOriginal(
@@ -369,8 +371,8 @@ private fun ApplicationScope.TrayAppImplOriginal(
     state: TrayAppState?,
     windowSize: DpSize?,
     visibleOnStart: Boolean,
-    fadeDurationMs: Int,
-    animationSpec: AnimationSpec<Float>,
+    enterTransition: EnterTransition,
+    exitTransition: ExitTransition,
     transparent: Boolean,
     windowsTitle: String,
     windowIcon: Painter?,
@@ -381,21 +383,19 @@ private fun ApplicationScope.TrayAppImplOriginal(
     menu: (TrayMenuBuilder.() -> Unit)?,
     content: @Composable DialogWindowScope.() -> Unit,
 ) {
-    // State holder
     val trayAppState = state ?: rememberTrayAppState(
         initialWindowSize = windowSize ?: DpSize(300.dp, 200.dp),
         initiallyVisible = visibleOnStart,
         initialDismissMode = TrayWindowDismissMode.AUTO
     )
-
     val isVisible by trayAppState.isVisible.collectAsState()
     val currentWindowSize by trayAppState.windowSize.collectAsState()
     val dismissMode by trayAppState.dismissMode.collectAsState()
 
     val tray = remember { NativeTray() }
-
     val isDark = isMenuBarInDarkMode()
-    val contentHash = ComposableIconUtils.calculateContentHash(iconRenderProperties, iconContent) + isDark.hashCode()
+    val contentHash =
+        ComposableIconUtils.calculateContentHash(iconRenderProperties, iconContent) + isDark.hashCode()
     val pngIconPath = remember(contentHash) {
         ComposableIconUtils.renderComposableToPngFile(iconRenderProperties, iconContent)
     }
@@ -405,12 +405,6 @@ private fun ApplicationScope.TrayAppImplOriginal(
         else pngIconPath
     }
     val menuHash = MenuContentHash.calculateMenuHash(menu)
-
-    val alpha by animateFloatAsState(
-        targetValue = if (isVisible) 1f else 0f,
-        animationSpec = animationSpec,
-        label = "window_fade"
-    )
 
     var shouldShowWindow by remember { mutableStateOf(false) }
 
@@ -426,8 +420,10 @@ private fun ApplicationScope.TrayAppImplOriginal(
     var autoHideEnabledAt by remember { mutableStateOf(0L) }
 
     val dialogState = rememberDialogState(size = currentWindowSize)
-
     LaunchedEffect(currentWindowSize) { dialogState.size = currentWindowSize }
+
+    // Visibility controller for AnimatedVisibility to observe end of exit animation
+    val visibleState = remember { MutableTransitionState(false) }
 
     val requestHideExplicit: () -> Unit = {
         val now = System.currentTimeMillis()
@@ -464,10 +460,12 @@ private fun ApplicationScope.TrayAppImplOriginal(
     }
 
     LaunchedEffect(isVisible) {
+        // Drive AnimatedVisibility
+        visibleState.targetState = isVisible
+
         if (isVisible) {
             if (!shouldShowWindow) {
-                // Slight delay lets the tray click/dock animations settle (macOS)
-                delay(150)
+                delay(150) // Let tray click/dock settle (macOS)
                 val widthPx = currentWindowSize.width.value.toInt()
                 val heightPx = currentWindowSize.height.value.toInt()
                 var position: WindowPosition = WindowPosition.PlatformDefault
@@ -487,9 +485,13 @@ private fun ApplicationScope.TrayAppImplOriginal(
                 lastShownAt = System.currentTimeMillis()
             }
         } else {
-            delay(fadeDurationMs.toLong())
-            shouldShowWindow = false
-            lastHiddenAt = System.currentTimeMillis()
+            // Wait for exit transition to fully finish, then actually hide the window
+            if (shouldShowWindow) {
+                snapshotFlow { visibleState.isIdle && !visibleState.currentState }
+                    .first { it }
+                shouldShowWindow = false
+                lastHiddenAt = System.currentTimeMillis()
+            }
         }
     }
 
@@ -576,11 +578,18 @@ private fun ApplicationScope.TrayAppImplOriginal(
             }
         }
 
-        Box(modifier = Modifier.fillMaxSize().alpha(alpha)) { content() }
+        // Configurable content animation; window hides only after exit finishes
+        AnimatedVisibility(
+            visibleState = visibleState,
+            enter = enterTransition,
+            exit = exitTransition
+        ) {
+            Box(modifier = Modifier.fillMaxSize()) { content() }
+        }
     }
 }
 
-// --------------------- Impl: Linux (new logic) ---------------------
+// --------------------- Impl: Linux ---------------------
 
 @Composable
 private fun ApplicationScope.TrayAppImplLinux(
@@ -590,8 +599,8 @@ private fun ApplicationScope.TrayAppImplLinux(
     state: TrayAppState?,
     windowSize: DpSize?,
     visibleOnStart: Boolean,
-    fadeDurationMs: Int,
-    animationSpec: AnimationSpec<Float>,
+    enterTransition: EnterTransition,
+    exitTransition: ExitTransition,
     transparent: Boolean,
     windowsTitle: String,
     windowIcon: Painter?,
@@ -602,13 +611,11 @@ private fun ApplicationScope.TrayAppImplLinux(
     menu: (TrayMenuBuilder.() -> Unit)?,
     content: @Composable DialogWindowScope.() -> Unit,
 ) {
-    // State holder (window always mounted; visibility toggled)
     val trayAppState = state ?: rememberTrayAppState(
         initialWindowSize = windowSize ?: DpSize(300.dp, 200.dp),
         initiallyVisible = visibleOnStart,
         initialDismissMode = TrayWindowDismissMode.AUTO
     )
-
     val isVisible by trayAppState.isVisible.collectAsState()
     val currentWindowSize by trayAppState.windowSize.collectAsState()
     val dismissMode by trayAppState.dismissMode.collectAsState()
@@ -617,16 +624,11 @@ private fun ApplicationScope.TrayAppImplLinux(
     val instanceKey = remember { tray.instanceKey() }
 
     val isDark = isMenuBarInDarkMode()
-    val contentHash = ComposableIconUtils.calculateContentHash(iconRenderProperties, iconContent) + isDark.hashCode()
+    val contentHash =
+        ComposableIconUtils.calculateContentHash(iconRenderProperties, iconContent) + isDark.hashCode()
     val pngIconPath = remember(contentHash) { ComposableIconUtils.renderComposableToPngFile(iconRenderProperties, iconContent) }
-    val windowsIconPath = pngIconPath // Linux doesn't use .ico
+    val windowsIconPath = pngIconPath
     val menuHash = MenuContentHash.calculateMenuHash(menu)
-
-    val alpha by animateFloatAsState(
-        targetValue = if (isVisible) 1f else 0f,
-        animationSpec = animationSpec,
-        label = "window_fade"
-    )
 
     var shouldShowWindow by remember { mutableStateOf(false) }
     var lastPrimaryActionAt by remember { mutableStateOf(0L) }
@@ -636,7 +638,6 @@ private fun ApplicationScope.TrayAppImplLinux(
     val minVisibleDurationMs = 350L
     val minHiddenDurationMs = 250L
 
-    // Seed initial position BEFORE creating DialogWindow
     val initialPositionForFirstFrame = remember(instanceKey, currentWindowSize) {
         val w = currentWindowSize.width.value.toInt()
         val h = currentWindowSize.height.value.toInt()
@@ -646,6 +647,9 @@ private fun ApplicationScope.TrayAppImplLinux(
     val dialogState = rememberDialogState(position = initialPositionForFirstFrame, size = currentWindowSize)
     SideEffect { dialogState.position = initialPositionForFirstFrame }
     LaunchedEffect(currentWindowSize) { dialogState.size = currentWindowSize }
+
+    // Visibility controller for exit-finish detection
+    val visibleState = remember { MutableTransitionState(false) }
 
     val requestHideExplicit: () -> Unit = {
         val now = System.currentTimeMillis()
@@ -676,6 +680,9 @@ private fun ApplicationScope.TrayAppImplLinux(
     }
 
     LaunchedEffect(isVisible) {
+        // Drive AnimatedVisibility
+        visibleState.targetState = isVisible
+
         if (isVisible) {
             if (!shouldShowWindow) {
                 val w = currentWindowSize.width.value.toInt()
@@ -685,13 +692,16 @@ private fun ApplicationScope.TrayAppImplLinux(
                 lastShownAt = System.currentTimeMillis()
             }
         } else {
-            delay(fadeDurationMs.toLong())
-            shouldShowWindow = false
-            lastHiddenAt = System.currentTimeMillis()
+            if (shouldShowWindow) {
+                snapshotFlow { visibleState.isIdle && !visibleState.currentState }
+                    .first { it }
+                shouldShowWindow = false
+                lastHiddenAt = System.currentTimeMillis()
+            }
         }
     }
 
-    // Re-anchor on size change while visible (important for KWin/GNOME)
+    // Re-anchor when visible and size changes
     LaunchedEffect(currentWindowSize, shouldShowWindow) {
         if (shouldShowWindow) {
             val w = currentWindowSize.width.value.toInt()
@@ -712,7 +722,7 @@ private fun ApplicationScope.TrayAppImplLinux(
         icon = windowIcon,
         undecorated = undecorated,
         resizable = resizable,
-        focusable = shouldShowWindow, // avoid focus-steal while hidden
+        focusable = shouldShowWindow,
         alwaysOnTop = true,
         transparent = transparent,
         visible = shouldShowWindow,
@@ -723,14 +733,12 @@ private fun ApplicationScope.TrayAppImplLinux(
         DisposableEffect(shouldShowWindow, dismissMode) {
             if (!shouldShowWindow) return@DisposableEffect onDispose { }
 
-            // Ensure anchor once the AWT peer exists
             runCatching {
                 val w = currentWindowSize.width.value.toInt()
                 val h = currentWindowSize.height.value.toInt()
                 dialogState.position = getTrayWindowPositionForInstance(instanceKey, w, h)
             }
 
-            // Linux outside-click watcher
             val linuxWatcher = if (dismissMode == TrayWindowDismissMode.AUTO) {
                 LinuxOutsideClickWatcher(
                     windowSupplier = { window },
@@ -745,11 +753,15 @@ private fun ApplicationScope.TrayAppImplLinux(
                 }
             })
 
-            onDispose {
-                linuxWatcher?.stop()
-            }
+            onDispose { linuxWatcher?.stop() }
         }
 
-        Box(modifier = Modifier.fillMaxSize().alpha(alpha)) { content() }
+        AnimatedVisibility(
+            visibleState = visibleState,
+            enter = enterTransition,
+            exit = exitTransition
+        ) {
+            Box(modifier = Modifier.fillMaxSize()) { content() }
+        }
     }
 }

--- a/src/commonMain/kotlin/com/kdroid/composetray/tray/api/TrayApp.kt
+++ b/src/commonMain/kotlin/com/kdroid/composetray/tray/api/TrayApp.kt
@@ -13,6 +13,7 @@ import androidx.compose.runtime.*
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.ColorFilter
+import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.graphics.painter.Painter
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.input.key.KeyEvent
@@ -653,7 +654,7 @@ private fun ApplicationScope.TrayAppImplOriginal(
         AnimatedVisibility(
             visibleState = visibleState, enter = enterTransition, exit = exitTransition
         ) {
-            Box(modifier = Modifier.fillMaxSize()) { content() }
+            Box(modifier = Modifier.fillMaxSize().graphicsLayer().animateEnterExit()) { content() }
         }
     }
 }

--- a/src/commonMain/kotlin/com/kdroid/composetray/tray/api/TrayApp.kt
+++ b/src/commonMain/kotlin/com/kdroid/composetray/tray/api/TrayApp.kt
@@ -45,7 +45,7 @@ import java.awt.event.WindowFocusListener
 
 val defaultTrayAppEnterTransition = if (getOperatingSystem() == WINDOWS) slideInVertically(
     initialOffsetY = { fullHeight -> fullHeight },
-    animationSpec = tween(200, easing = EaseInOut)
+    animationSpec = tween(250, easing = EaseInOut)
 ) + fadeIn(animationSpec = tween(200, easing = EaseInOut)) else fadeIn(
     animationSpec = tween(
         200,
@@ -55,7 +55,7 @@ val defaultTrayAppEnterTransition = if (getOperatingSystem() == WINDOWS) slideIn
 
 val defaultTrayAppExitTransition = if (getOperatingSystem() == WINDOWS) slideOutVertically(
     targetOffsetY = { fullHeight -> fullHeight },
-    animationSpec = tween(200, easing = EaseInOut)
+    animationSpec = tween(250, easing = EaseInOut)
 ) + fadeOut(animationSpec = tween(200, easing = EaseInOut)) else fadeOut(
     animationSpec = tween(
         200,

--- a/src/commonMain/kotlin/com/kdroid/composetray/tray/api/TrayApp.kt
+++ b/src/commonMain/kotlin/com/kdroid/composetray/tray/api/TrayApp.kt
@@ -2,23 +2,14 @@
 
 package com.kdroid.composetray.tray.api
 
-import androidx.compose.animation.AnimatedVisibility
-import androidx.compose.animation.EnterTransition
-import androidx.compose.animation.ExitTransition
-import androidx.compose.animation.fadeIn
-import androidx.compose.animation.fadeOut
+import androidx.compose.animation.*
 import androidx.compose.animation.core.EaseInOut
 import androidx.compose.animation.core.MutableTransitionState
 import androidx.compose.animation.core.tween
-import androidx.compose.animation.expandVertically
-import androidx.compose.animation.shrinkVertically
-import androidx.compose.animation.slideInVertically
-import androidx.compose.animation.slideOutVertically
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.*
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.ColorFilter
@@ -27,11 +18,7 @@ import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.input.key.KeyEvent
 import androidx.compose.ui.unit.DpSize
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.window.ApplicationScope
-import androidx.compose.ui.window.DialogWindow
-import androidx.compose.ui.window.DialogWindowScope
-import androidx.compose.ui.window.WindowPosition
-import androidx.compose.ui.window.rememberDialogState
+import androidx.compose.ui.window.*
 import com.kdroid.composetray.lib.linux.LinuxOutsideClickWatcher
 import com.kdroid.composetray.lib.mac.MacOSWindowManager
 import com.kdroid.composetray.lib.mac.MacOutsideClickWatcher
@@ -56,6 +43,26 @@ import java.awt.event.WindowFocusListener
 
 // --------------------- Public API (overloads) ---------------------
 
+val defaultTrayAppEnterTransition = if (getOperatingSystem() == WINDOWS) slideInVertically(
+    initialOffsetY = { fullHeight -> fullHeight },
+    animationSpec = tween(200, easing = EaseInOut)
+) + fadeIn(animationSpec = tween(200, easing = EaseInOut)) else fadeIn(
+    animationSpec = tween(
+        200,
+        easing = EaseInOut
+    )
+)
+
+val defaultTrayAppExitTransition = if (getOperatingSystem() == WINDOWS) slideOutVertically(
+    targetOffsetY = { fullHeight -> fullHeight },
+    animationSpec = tween(200, easing = EaseInOut)
+) + fadeOut(animationSpec = tween(200, easing = EaseInOut)) else fadeOut(
+    animationSpec = tween(
+        200,
+        easing = EaseInOut
+    )
+)
+
 @ExperimentalTrayAppApi
 @Composable
 fun ApplicationScope.TrayApp(
@@ -66,24 +73,8 @@ fun ApplicationScope.TrayApp(
     state: TrayAppState? = null,
     windowSize: DpSize? = null,
     visibleOnStart: Boolean = false,
-    enterTransition: EnterTransition = if (getOperatingSystem() == WINDOWS) slideInVertically(
-        initialOffsetY = { fullHeight -> fullHeight },
-        animationSpec = tween(200, easing = EaseInOut)
-    ) + fadeIn(animationSpec = tween(200, easing = EaseInOut)) else fadeIn(
-        animationSpec = tween(
-            200,
-            easing = EaseInOut
-        )
-    ),
-    exitTransition: ExitTransition = if (getOperatingSystem() == WINDOWS) slideOutVertically(
-        targetOffsetY = { fullHeight -> fullHeight },
-        animationSpec = tween(200, easing = EaseInOut)
-    ) + fadeOut(animationSpec = tween(200, easing = EaseInOut)) else fadeOut(
-        animationSpec = tween(
-            200,
-            easing = EaseInOut
-        )
-    ),
+    enterTransition: EnterTransition = defaultTrayAppEnterTransition,
+    exitTransition: ExitTransition = defaultTrayAppExitTransition,
     transparent: Boolean = true,
     windowsTitle: String = "",
     windowIcon: Painter? = null,
@@ -134,8 +125,8 @@ fun ApplicationScope.TrayApp(
     state: TrayAppState? = null,
     windowSize: DpSize? = null,
     visibleOnStart: Boolean = false,
-    enterTransition: EnterTransition = fadeIn(animationSpec = tween(200, easing = EaseInOut)),
-    exitTransition: ExitTransition = fadeOut(animationSpec = tween(200, easing = EaseInOut)),
+    enterTransition: EnterTransition = defaultTrayAppEnterTransition,
+    exitTransition: ExitTransition = defaultTrayAppExitTransition,
     transparent: Boolean = true,
     windowsTitle: String = "",
     windowIcon: Painter? = null,
@@ -182,8 +173,8 @@ fun ApplicationScope.TrayApp(
     state: TrayAppState? = null,
     windowSize: DpSize? = null,
     visibleOnStart: Boolean = false,
-    enterTransition: EnterTransition = fadeIn(animationSpec = tween(200, easing = EaseInOut)),
-    exitTransition: ExitTransition = fadeOut(animationSpec = tween(200, easing = EaseInOut)),
+    enterTransition: EnterTransition = defaultTrayAppEnterTransition,
+    exitTransition: ExitTransition = defaultTrayAppExitTransition,
     transparent: Boolean = true,
     windowsTitle: String = "",
     windowIcon: Painter? = null,
@@ -247,8 +238,8 @@ fun ApplicationScope.TrayApp(
     state: TrayAppState? = null,
     windowSize: DpSize? = null,
     visibleOnStart: Boolean = false,
-    enterTransition: EnterTransition = fadeIn(animationSpec = tween(200, easing = EaseInOut)),
-    exitTransition: ExitTransition = fadeOut(animationSpec = tween(200, easing = EaseInOut)),
+    enterTransition: EnterTransition = defaultTrayAppEnterTransition,
+    exitTransition: ExitTransition = defaultTrayAppExitTransition,
     transparent: Boolean = true,
     windowsTitle: String = "",
     windowIcon: Painter? = null,
@@ -289,8 +280,8 @@ fun ApplicationScope.TrayApp(
     state: TrayAppState? = null,
     windowSize: DpSize? = null,
     visibleOnStart: Boolean = false,
-    enterTransition: EnterTransition = fadeIn(animationSpec = tween(200, easing = EaseInOut)),
-    exitTransition: ExitTransition = fadeOut(animationSpec = tween(200, easing = EaseInOut)),
+    enterTransition: EnterTransition = defaultTrayAppEnterTransition,
+    exitTransition: ExitTransition = defaultTrayAppExitTransition,
     transparent: Boolean = true,
     windowsTitle: String = "",
     windowIcon: Painter? = null,
@@ -356,8 +347,8 @@ fun ApplicationScope.TrayApp(
     state: TrayAppState? = null,
     windowSize: DpSize? = null,
     visibleOnStart: Boolean = false,
-    enterTransition: EnterTransition = fadeIn(animationSpec = tween(200, easing = EaseInOut)),
-    exitTransition: ExitTransition = fadeOut(animationSpec = tween(200, easing = EaseInOut)),
+    enterTransition: EnterTransition = defaultTrayAppEnterTransition,
+    exitTransition: ExitTransition = defaultTrayAppExitTransition,
     transparent: Boolean = true,
     windowsTitle: String = "",
     windowIcon: Painter? = null,

--- a/src/commonMain/kotlin/com/kdroid/composetray/tray/api/TrayApp.kt
+++ b/src/commonMain/kotlin/com/kdroid/composetray/tray/api/TrayApp.kt
@@ -68,7 +68,7 @@ private val defaultTrayAppExitTransition =
 
 private val defaultVerticalOffset = when (getOperatingSystem()) {
     WINDOWS -> -10
-    MACOS -> 5
+    MACOS -> 30
     else -> when (detectLinuxDesktopEnvironment()) {
         LinuxDesktopEnvironment.GNOME -> 10
         else -> 0
@@ -741,6 +741,7 @@ private fun ApplicationScope.TrayAppImplLinux(
     }
 
     val dialogState = rememberDialogState(position = initialPositionForFirstFrame, size = currentWindowSize)
+    if (detectLinuxDesktopEnvironment() == LinuxDesktopEnvironment.KDE) SideEffect { dialogState.position = initialPositionForFirstFrame }
     LaunchedEffect(currentWindowSize) { dialogState.size = currentWindowSize }
 
     // Visibility controller for exit-finish detection; content will NOT be disposed.

--- a/src/commonMain/kotlin/com/kdroid/composetray/tray/api/TrayApp.kt
+++ b/src/commonMain/kotlin/com/kdroid/composetray/tray/api/TrayApp.kt
@@ -70,7 +70,7 @@ private val defaultVerticalOffset = when (getOperatingSystem()) {
     WINDOWS -> -10
     MACOS -> 30
     else -> when (detectLinuxDesktopEnvironment()) {
-        LinuxDesktopEnvironment.GNOME -> 25
+        LinuxDesktopEnvironment.GNOME -> 10
         else -> 0
     }
 }

--- a/src/commonMain/kotlin/com/kdroid/composetray/tray/api/TrayApp.kt
+++ b/src/commonMain/kotlin/com/kdroid/composetray/tray/api/TrayApp.kt
@@ -707,6 +707,7 @@ private fun ApplicationScope.TrayAppImplLinux(
     menu: (TrayMenuBuilder.() -> Unit)?,
     content: @Composable DialogWindowScope.() -> Unit,
 ) {
+    val isKde = detectLinuxDesktopEnvironment() == LinuxDesktopEnvironment.KDE
     val trayAppState = state ?: rememberTrayAppState(
         initialWindowSize = windowSize ?: DpSize(300.dp, 200.dp),
         initiallyVisible = visibleOnStart,
@@ -741,7 +742,7 @@ private fun ApplicationScope.TrayAppImplLinux(
     }
 
     val dialogState = rememberDialogState(position = initialPositionForFirstFrame, size = currentWindowSize)
-    if (detectLinuxDesktopEnvironment() == LinuxDesktopEnvironment.KDE) SideEffect { dialogState.position = initialPositionForFirstFrame }
+    if (isKde) SideEffect { dialogState.position = initialPositionForFirstFrame }
     LaunchedEffect(currentWindowSize) { dialogState.size = currentWindowSize }
 
     // Visibility controller for exit-finish detection; content will NOT be disposed.

--- a/src/commonMain/kotlin/com/kdroid/composetray/utils/PersistentAnimatedVisibility.kt
+++ b/src/commonMain/kotlin/com/kdroid/composetray/utils/PersistentAnimatedVisibility.kt
@@ -1,0 +1,246 @@
+package com.kdroid.composetray.utils
+
+import androidx.compose.animation.AnimatedVisibilityScope
+import androidx.compose.animation.EnterExitState
+import androidx.compose.animation.EnterTransition
+import androidx.compose.animation.ExitTransition
+import androidx.compose.animation.core.ExperimentalTransitionApi
+import androidx.compose.animation.core.InternalAnimationApi
+import androidx.compose.animation.core.MutableTransitionState
+import androidx.compose.animation.core.Transition
+import androidx.compose.animation.core.createChildTransition
+import androidx.compose.animation.core.rememberTransition
+import androidx.compose.animation.expandIn
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.shrinkOut
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.key
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.layout.IntrinsicMeasurable
+import androidx.compose.ui.layout.IntrinsicMeasureScope
+import androidx.compose.ui.layout.Layout
+import androidx.compose.ui.layout.Measurable
+import androidx.compose.ui.layout.MeasurePolicy
+import androidx.compose.ui.layout.MeasureResult
+import androidx.compose.ui.layout.MeasureScope
+import androidx.compose.ui.layout.layout
+import androidx.compose.ui.unit.Constraints
+import androidx.compose.ui.unit.IntSize
+import androidx.compose.ui.util.fastForEach
+import androidx.compose.ui.util.fastMap
+import androidx.compose.ui.util.fastMaxOfOrDefault
+import kotlin.math.max
+
+
+@Composable
+internal fun PersistentAnimatedVisibility(
+    visibleState: MutableTransitionState<Boolean>,
+    modifier: Modifier = Modifier,
+    enter: EnterTransition = fadeIn() + expandIn(),
+    exit: ExitTransition = fadeOut() + shrinkOut(),
+    label: String = "PersistentAnimatedVisibility",
+    content: @Composable AnimatedVisibilityScope.() -> Unit,
+) {
+    // Hoisted transition identical to AnimatedVisibility(visibleState = ...)
+    val transition = rememberTransition(visibleState, label)
+    AnimatedVisibilityImplPersistent(
+        transition = transition,
+        visible = { it }, // Boolean target in MutableTransitionState<Boolean>
+        modifier = modifier.layout { measurable, constraints ->
+            // Report 0 size only during lookahead when target is "not visible"
+            val placeable = measurable.measure(constraints)
+            val (w, h) =
+                if (isLookingAhead && !transition.targetState) {
+                    IntSize.Zero
+                } else {
+                    IntSize(placeable.width, placeable.height)
+                }
+            layout(w, h) { placeable.place(0, 0) }
+        },
+        enter = enter,
+        exit = exit,
+        content = content
+    )
+}
+
+@Composable
+private fun <T> AnimatedVisibilityImplPersistent(
+    transition: Transition<T>,
+    visible: (T) -> Boolean,
+    modifier: Modifier,
+    enter: EnterTransition,
+    exit: ExitTransition,
+    content: @Composable AnimatedVisibilityScope.() -> Unit,
+) {
+    AnimatedEnterExitImplPersistent(
+        transition = transition,
+        visible = visible,
+        modifier = modifier,
+        enter = enter,
+        exit = exit,
+        // <-- never dispose content; it stays composed after exit finishes
+        shouldDisposeBlock = { _, _ -> false },
+        content = content
+    )
+}
+
+// --- Scope "maison" (public API only) ---
+private class AVScopeImpl(
+    override var transition: Transition<EnterExitState>
+) : AnimatedVisibilityScope {
+    val targetSize = mutableStateOf(IntSize.Zero)
+}
+
+private class AVMeasurePolicy(private val scope: AVScopeImpl) : MeasurePolicy {
+    private var hasLookaheadOccurred = false
+
+    override fun MeasureScope.measure(
+        measurables: List<Measurable>, constraints: Constraints
+    ): MeasureResult {
+        var maxW = 0; var maxH = 0
+        val placeables = measurables.map {
+            it.measure(constraints).also { p ->
+                if (p.width > maxW) maxW = p.width
+                if (p.height > maxH) maxH = p.height
+            }
+        }
+        if (isLookingAhead) {
+            hasLookaheadOccurred = true
+            scope.targetSize.value = IntSize(maxW, maxH)
+        } else if (!hasLookaheadOccurred) {
+            scope.targetSize.value = IntSize(maxW, maxH)
+        }
+        return layout(maxW, maxH) { placeables.forEach { it.place(0, 0) } }
+    }
+
+    override fun IntrinsicMeasureScope.minIntrinsicWidth(m: List<IntrinsicMeasurable>, h: Int) =
+        m.maxOfOrNull { it.minIntrinsicWidth(h) } ?: 0
+    override fun IntrinsicMeasureScope.minIntrinsicHeight(m: List<IntrinsicMeasurable>, w: Int) =
+        m.maxOfOrNull { it.minIntrinsicHeight(w) } ?: 0
+    override fun IntrinsicMeasureScope.maxIntrinsicWidth(m: List<IntrinsicMeasurable>, h: Int) =
+        m.maxOfOrNull { it.maxIntrinsicWidth(h) } ?: 0
+    override fun IntrinsicMeasureScope.maxIntrinsicHeight(m: List<IntrinsicMeasurable>, w: Int) =
+        m.maxOfOrNull { it.maxIntrinsicHeight(w) } ?: 0
+}
+
+@OptIn(
+    ExperimentalTransitionApi::class,
+    InternalAnimationApi::class
+)
+@Composable
+private fun <T> AnimatedEnterExitImplPersistent(
+    transition: Transition<T>,
+    visible: (T) -> Boolean,
+    modifier: Modifier,
+    enter: EnterTransition,
+    exit: ExitTransition,
+    // on garde la signature mais on ne dispose jamais (toujours false)
+    shouldDisposeBlock: (EnterExitState, EnterExitState) -> Boolean,
+    content: @Composable AnimatedVisibilityScope.() -> Unit,
+) {
+    if (
+        visible(transition.targetState) ||
+        visible(transition.currentState) ||
+        transition.isSeeking ||
+        transition.hasInitialValueAnimations
+    ) {
+        val child = transition.createChildTransition(label = "EnterExitTransition") {
+            transition.targetEnterExit(visible, it)
+        }
+
+        // On NE JAMAIS appelle createModifier(...) directement !
+        val scope = remember(transition) { AVScopeImpl(child) }
+
+        // Important: appliquer les transitions au conteneur via l’API publique
+        val animatedContainerModifier = with(scope) {
+            Modifier.animateEnterExit(enter = enter, exit = exit, label = "Built-in")
+        }
+
+        Layout(
+            content = { scope.content() },
+            modifier = modifier.then(animatedContainerModifier),
+            measurePolicy = remember { AVMeasurePolicy(scope) },
+        )
+    }
+}
+
+private val Transition<EnterExitState>.exitFinished: Boolean
+    get() = currentState == EnterExitState.PostExit && targetState == EnterExitState.PostExit
+
+private class AnimatedVisibilityScopeImpl(transition: Transition<EnterExitState>) :
+    AnimatedVisibilityScope {
+    override var transition: Transition<EnterExitState> = transition
+    internal val targetSize = mutableStateOf(IntSize.Zero)
+}
+
+private class AnimatedEnterExitMeasurePolicy(val scope: AnimatedVisibilityScopeImpl) : MeasurePolicy {
+    var hasLookaheadOccurred = false
+
+    override fun MeasureScope.measure(
+        measurables: List<Measurable>,
+        constraints: Constraints,
+    ): MeasureResult {
+        var maxWidth = 0
+        var maxHeight = 0
+        val placeables =
+            measurables.fastMap {
+                it.measure(constraints).apply {
+                    maxWidth = max(maxWidth, width)
+                    maxHeight = max(maxHeight, height)
+                }
+            }
+        if (isLookingAhead) {
+            hasLookaheadOccurred = true
+            scope.targetSize.value = IntSize(maxWidth, maxHeight)
+        } else if (!hasLookaheadOccurred) {
+            scope.targetSize.value = IntSize(maxWidth, maxHeight)
+        }
+        return layout(maxWidth, maxHeight) { placeables.fastForEach { it.place(0, 0) } }
+    }
+
+    override fun IntrinsicMeasureScope.minIntrinsicWidth(
+        measurables: List<IntrinsicMeasurable>,
+        height: Int,
+    ) = measurables.fastMaxOfOrDefault(0) { it.minIntrinsicWidth(height) }
+
+    override fun IntrinsicMeasureScope.minIntrinsicHeight(
+        measurables: List<IntrinsicMeasurable>,
+        width: Int,
+    ) = measurables.fastMaxOfOrDefault(0) { it.minIntrinsicHeight(width) }
+
+    override fun IntrinsicMeasureScope.maxIntrinsicWidth(
+        measurables: List<IntrinsicMeasurable>,
+        height: Int,
+    ) = measurables.fastMaxOfOrDefault(0) { it.maxIntrinsicWidth(height) }
+
+    override fun IntrinsicMeasureScope.maxIntrinsicHeight(
+        measurables: List<IntrinsicMeasurable>,
+        width: Int,
+    ) = measurables.fastMaxOfOrDefault(0) { it.maxIntrinsicHeight(width) }
+}
+
+// Convert Boolean visibility to EnterExitState, mirroring framework behavior.
+@Composable
+private fun <T> Transition<T>.targetEnterExit(
+    visible: (T) -> Boolean,
+    targetState: T,
+): EnterExitState = key(this) {
+    if (this.isSeeking) {
+        if (visible(targetState)) {
+            EnterExitState.Visible
+        } else {
+            if (visible(this.currentState)) EnterExitState.PostExit else EnterExitState.PreEnter
+        }
+    } else {
+        val hasBeenVisible = remember { mutableStateOf(false) }
+        if (visible(currentState)) hasBeenVisible.value = true
+        if (visible(targetState)) {
+            EnterExitState.Visible
+        } else {
+            if (hasBeenVisible.value) EnterExitState.PostExit else EnterExitState.PreEnter
+        }
+    }
+}

--- a/src/commonMain/kotlin/com/kdroid/composetray/utils/TrayPosition.kt
+++ b/src/commonMain/kotlin/com/kdroid/composetray/utils/TrayPosition.kt
@@ -12,26 +12,22 @@ import io.github.kdroidfilter.platformtools.detectLinuxDesktopEnvironment
 import io.github.kdroidfilter.platformtools.getOperatingSystem
 import java.awt.Toolkit
 import java.io.File
-import java.io.FileInputStream
 import java.util.*
 import java.util.concurrent.atomic.AtomicReference
 import kotlin.math.roundToInt
 
-enum class TrayPosition {
-    TOP_LEFT, TOP_RIGHT, BOTTOM_LEFT, BOTTOM_RIGHT
-}
+enum class TrayPosition { TOP_LEFT, TOP_RIGHT, BOTTOM_LEFT, BOTTOM_RIGHT }
 
-// Data class to store exact tray click coordinates
 data class TrayClickPosition(
     val x: Int,
     val y: Int,
     val position: TrayPosition
 )
 
-// Global storage for last click position
 internal object TrayClickTracker {
     private val lastClickPosition = AtomicReference<TrayClickPosition?>(null)
-    private val perInstancePositions: MutableMap<String, TrayClickPosition> = Collections.synchronizedMap(mutableMapOf())
+    private val perInstancePositions: MutableMap<String, TrayClickPosition> =
+        Collections.synchronizedMap(mutableMapOf())
 
     fun updateClickPosition(x: Int, y: Int) {
         val screenSize = Toolkit.getDefaultToolkit().screenSize
@@ -46,7 +42,6 @@ internal object TrayClickTracker {
         val position = convertPositionToCorner(x, y, screenSize.width, screenSize.height)
         val pos = TrayClickPosition(x, y, position)
         perInstancePositions[instanceId] = pos
-        // Also update the global fallback to the most recent interaction
         lastClickPosition.set(pos)
         runCatching { saveTrayClickPosition(x, y, position) }
     }
@@ -60,23 +55,19 @@ internal object TrayClickTracker {
     fun setClickPosition(instanceId: String, x: Int, y: Int, position: TrayPosition) {
         val pos = TrayClickPosition(x, y, position)
         perInstancePositions[instanceId] = pos
-        // Update global fallback too
         lastClickPosition.set(pos)
         runCatching { saveTrayClickPosition(x, y, position) }
     }
 
     fun getLastClickPosition(): TrayClickPosition? = lastClickPosition.get()
-
     fun getLastClickPosition(instanceId: String): TrayClickPosition? = perInstancePositions[instanceId]
 }
 
-internal fun convertPositionToCorner(x: Int, y: Int, width: Int, height: Int): TrayPosition {
-    return when {
-        x < width / 2 && y < height / 2 -> TrayPosition.TOP_LEFT
-        x >= width / 2 && y < height / 2 -> TrayPosition.TOP_RIGHT
-        x < width / 2 && y >= height / 2 -> TrayPosition.BOTTOM_LEFT
-        else -> TrayPosition.BOTTOM_RIGHT
-    }
+internal fun convertPositionToCorner(x: Int, y: Int, width: Int, height: Int): TrayPosition = when {
+    x < width / 2 && y < height / 2 -> TrayPosition.TOP_LEFT
+    x >= width / 2 && y < height / 2 -> TrayPosition.TOP_RIGHT
+    x < width / 2 && y >= height / 2 -> TrayPosition.BOTTOM_LEFT
+    else -> TrayPosition.BOTTOM_RIGHT
 }
 
 private const val PROPERTIES_FILE = "tray_position.properties"
@@ -84,37 +75,27 @@ private const val POSITION_KEY = "TrayPosition"
 private const val X_KEY = "TrayX"
 private const val Y_KEY = "TrayY"
 
-// Use a writable tmp/cache directory to avoid read-only filesystem issues (e.g., macOS app bundle working dir)
 private fun trayPropertiesFile(): File {
     val appId = AppIdProvider.appId()
     val tmpBase = System.getProperty("java.io.tmpdir") ?: "."
     val tmpDir = File(File(tmpBase, "ComposeNativeTray"), appId)
     val macCacheDir = macCacheDir()?.resolve(appId)
-
     val candidates = listOfNotNull(tmpDir, macCacheDir)
-
     for (dir in candidates) {
         runCatching { if (!dir.exists()) dir.mkdirs() }
-        if (dir.exists() && dir.canWrite()) {
-            return File(dir, PROPERTIES_FILE)
-        }
+        if (dir.exists() && dir.canWrite()) return File(dir, PROPERTIES_FILE)
     }
-
-    // Fallback to tmp even if not verified writable; write will be guarded by runCatching
     return File(tmpDir, PROPERTIES_FILE)
 }
 
-// Legacy properties file in working directory (for backward compatibility)
 private fun legacyPropertiesFile(): File = File(PROPERTIES_FILE)
 
-// Previous tmp location before appId namespacing (for backward-compatible reads only)
 private fun oldTmpPropertiesFile(): File {
     val tmpBase = System.getProperty("java.io.tmpdir") ?: "."
     val oldDir = File(tmpBase, "ComposeNativeTray")
     return File(oldDir, PROPERTIES_FILE)
 }
 
-// macOS user cache directory location for properties (for read/write fallback)
 private fun macCachePropertiesFile(): File? {
     val appId = AppIdProvider.appId()
     val dir = macCacheDir()?.resolve(appId) ?: return null
@@ -134,10 +115,8 @@ private fun loadPropertiesFrom(file: File): Properties? {
 }
 
 private fun storePropertiesTo(file: File, props: Properties) {
-    // Ensure parent exists if any
     file.parentFile?.let { runCatching { if (!it.exists()) it.mkdirs() } }
     runCatching { file.outputStream().use { props.store(it, null) } }
-    // We intentionally swallow exceptions to avoid crashing if the FS is read-only
 }
 
 internal fun saveTrayPosition(position: TrayPosition) {
@@ -165,7 +144,6 @@ internal fun saveTrayClickPosition(x: Int, y: Int, position: TrayPosition) {
 }
 
 internal fun loadTrayClickPosition(): TrayClickPosition? {
-    // Prefer new location, fallback to mac cache, then old tmp location, then legacy working dir
     val props = loadPropertiesFrom(trayPropertiesFile())
         ?: macCachePropertiesFile()?.let { loadPropertiesFrom(it) }
         ?: loadPropertiesFrom(oldTmpPropertiesFile())
@@ -177,117 +155,71 @@ internal fun loadTrayClickPosition(): TrayClickPosition? {
 
     return try {
         TrayClickPosition(x, y, TrayPosition.valueOf(positionStr))
-    } catch (e: IllegalArgumentException) {
+    } catch (_: IllegalArgumentException) {
         null
     }
 }
 
-internal fun getWindowsTrayPosition(nativeResult: String?): TrayPosition {
-    return when (nativeResult) {
-        null -> throw IllegalArgumentException("Returned value is null")
-        "top-left" -> TrayPosition.TOP_LEFT
-        "top-right" -> TrayPosition.TOP_RIGHT
-        "bottom-left" -> TrayPosition.BOTTOM_LEFT
-        "bottom-right" -> TrayPosition.BOTTOM_RIGHT
-        else -> throw IllegalArgumentException("Unknown value: $nativeResult")
-    }
+internal fun getWindowsTrayPosition(nativeResult: String?): TrayPosition = when (nativeResult) {
+    null -> throw IllegalArgumentException("Returned value is null")
+    "top-left" -> TrayPosition.TOP_LEFT
+    "top-right" -> TrayPosition.TOP_RIGHT
+    "bottom-left" -> TrayPosition.BOTTOM_LEFT
+    "bottom-right" -> TrayPosition.BOTTOM_RIGHT
+    else -> throw IllegalArgumentException("Unknown value: $nativeResult")
 }
 
-/**
- * Determines the position of the system tray icons based on the current operating system.
- *
- * The method evaluates the operating system in use and retrieves the corresponding tray position.
- * - On Windows, it uses the platform's native library to determine the tray position.
- * - On macOS, it defaults to a specific standard position.
- * - On Linux, the position is fetched from click coordinates or properties file.
- *   If no position data is available, it uses desktop environment-specific defaults:
- *   - GNOME: TOP_RIGHT
- *   - KDE: BOTTOM_RIGHT
- *   - XFCE: TOP_RIGHT
- *   - CINNAMON: BOTTOM_RIGHT
- *   - MATE: TOP_RIGHT
- * - For unknown or unsupported operating systems, a default position is returned.
- *
- * @return The computed tray position as a [TrayPosition] enum value.
- */
+/** OS → Tray corner heuristics */
 fun getTrayPosition(): TrayPosition {
-    when (getOperatingSystem()) {
-        OperatingSystem.WINDOWS -> {
-            return getWindowsTrayPosition(WindowsNativeTrayLibrary.tray_get_notification_icons_region())
-        }
-        OperatingSystem.MACOS -> {
-            val lib = MacTrayLoader.lib
-            return getMacTrayPosition(lib.tray_get_status_item_region())
-        }
+    return when (getOperatingSystem()) {
+        OperatingSystem.WINDOWS -> getWindowsTrayPosition(WindowsNativeTrayLibrary.tray_get_notification_icons_region())
+        OperatingSystem.MACOS -> getMacTrayPosition(MacTrayLoader.lib.tray_get_status_item_region())
         OperatingSystem.LINUX -> {
-            // First check if we have a recent click position in memory
-            TrayClickTracker.getLastClickPosition()?.let {
-                return it.position
-            }
-
-            // Otherwise, try to load from properties file
-            loadTrayClickPosition()?.let {
-                return it.position
-            }
-
-            // Legacy fallback - just position without coordinates
-            run {
-                val props = loadPropertiesFrom(trayPropertiesFile())
-                    ?: macCachePropertiesFile()?.let { loadPropertiesFrom(it) }
-                    ?: loadPropertiesFrom(oldTmpPropertiesFile())
-                    ?: loadPropertiesFrom(legacyPropertiesFile())
-                val position = props?.getProperty(POSITION_KEY, null)
-                if (position != null) {
-                    return try {
-                        TrayPosition.valueOf(position)
-                    } catch (e: IllegalArgumentException) {
-                        TrayPosition.TOP_RIGHT
+            TrayClickTracker.getLastClickPosition()?.position
+                ?: loadTrayClickPosition()?.position
+                ?: run {
+                    val props = loadPropertiesFrom(trayPropertiesFile())
+                        ?: macCachePropertiesFile()?.let { loadPropertiesFrom(it) }
+                        ?: loadPropertiesFrom(oldTmpPropertiesFile())
+                        ?: loadPropertiesFrom(legacyPropertiesFile())
+                    props?.getProperty(POSITION_KEY)?.let {
+                        runCatching { TrayPosition.valueOf(it) }.getOrNull()
                     }
                 }
-            }
-
-            // If no position is found, use desktop environment-specific defaults
-            return when (detectLinuxDesktopEnvironment()) {
-                LinuxDesktopEnvironment.GNOME -> TrayPosition.TOP_RIGHT
-                LinuxDesktopEnvironment.KDE -> TrayPosition.BOTTOM_RIGHT
-                LinuxDesktopEnvironment.XFCE -> TrayPosition.TOP_RIGHT
-                LinuxDesktopEnvironment.CINNAMON -> TrayPosition.BOTTOM_RIGHT
-                LinuxDesktopEnvironment.MATE -> TrayPosition.TOP_RIGHT
-                LinuxDesktopEnvironment.UNKNOWN -> TrayPosition.TOP_RIGHT
-                null -> TrayPosition.TOP_RIGHT
-            }
+                ?: when (detectLinuxDesktopEnvironment()) {
+                    LinuxDesktopEnvironment.KDE      -> TrayPosition.BOTTOM_RIGHT
+                    LinuxDesktopEnvironment.CINNAMON -> TrayPosition.BOTTOM_RIGHT
+                    LinuxDesktopEnvironment.GNOME    -> TrayPosition.TOP_RIGHT
+                    LinuxDesktopEnvironment.MATE     -> TrayPosition.TOP_RIGHT
+                    LinuxDesktopEnvironment.XFCE     -> TrayPosition.TOP_RIGHT
+                    else                             -> TrayPosition.TOP_RIGHT
+                }
         }
-        OperatingSystem.UNKNOWN -> return TrayPosition.TOP_RIGHT
-        else -> {}
+        OperatingSystem.UNKNOWN -> TrayPosition.TOP_RIGHT
+        else -> TrayPosition.TOP_RIGHT
     }
-    return TrayPosition.TOP_RIGHT
 }
 
-/**
- * Calculates the position of a tray window on the screen based on the current tray position and given window dimensions.
- *
- * This method determines the coordinates (x, y) where the tray window should be positioned, ensuring alignment
- * with the current system tray's placement. For Linux, it uses the exact click coordinates when available.
- *
- * @param windowWidth The width of the tray window in pixels.
- * @param windowHeight The height of the tray window in pixels.
- * @return The calculated position as a [WindowPosition] object containing the x and y coordinates.
- */
-fun getTrayWindowPosition(windowWidth: Int, windowHeight: Int): WindowPosition {
+/** Position globale (sans instance) + offsets */
+fun getTrayWindowPosition(
+    windowWidth: Int,
+    windowHeight: Int,
+    horizontalOffset: Int = 0,
+    verticalOffset: Int = 0
+): WindowPosition {
     val screenSize = Toolkit.getDefaultToolkit().screenSize
 
-    // Windows: use last precise click position captured on the tray thread; fallback to corner
     if (getOperatingSystem() == OperatingSystem.WINDOWS) {
         val freshPos = TrayClickTracker.getLastClickPosition()
-        val posToUse = freshPos ?: return fallbackCornerPosition(windowWidth, windowHeight)
+        val posToUse = freshPos ?: return fallbackCornerPosition(windowWidth, windowHeight, horizontalOffset, verticalOffset)
         return calculateWindowPositionFromClick(
             posToUse.x, posToUse.y, posToUse.position,
             windowWidth, windowHeight,
-            screenSize.width, screenSize.height
+            screenSize.width, screenSize.height,
+            horizontalOffset, verticalOffset
         )
     }
 
-    // macOS: try to fetch status item coordinates then compute precise window position
     if (getOperatingSystem() == OperatingSystem.MACOS) {
         val (x0, y0) = getStatusItemXYForMac()
         if (x0 != 0 || y0 != 0) {
@@ -298,181 +230,154 @@ fun getTrayWindowPosition(windowWidth: Int, windowHeight: Int): WindowPosition {
             return calculateWindowPositionFromClick(
                 pos.x, pos.y, pos.position,
                 windowWidth, windowHeight,
-                screenSize.width, screenSize.height
+                screenSize.width, screenSize.height,
+                horizontalOffset, verticalOffset
             )
         }
     }
 
-    // Linux: prefer exact click coordinates when available
     if (getOperatingSystem() == OperatingSystem.LINUX) {
         val clickPos = TrayClickTracker.getLastClickPosition() ?: loadTrayClickPosition()
         if (clickPos != null) {
             return calculateWindowPositionFromClick(
                 clickPos.x, clickPos.y, clickPos.position,
                 windowWidth, windowHeight,
-                screenSize.width, screenSize.height
+                screenSize.width, screenSize.height,
+                horizontalOffset, verticalOffset
             )
         }
     }
 
-    // Fallback to corner-based positioning
-    val trayPosition = getTrayPosition()
-    return when (trayPosition) {
-        TrayPosition.TOP_LEFT -> WindowPosition(x = 0.dp, y = 0.dp)
-        TrayPosition.TOP_RIGHT -> WindowPosition(x = (screenSize.width - windowWidth).dp, y = 0.dp)
-        TrayPosition.BOTTOM_LEFT -> WindowPosition(x = 0.dp, y = (screenSize.height - windowHeight).dp)
+    return when (getTrayPosition()) {
+        TrayPosition.TOP_LEFT -> WindowPosition(x = (0 + horizontalOffset).dp, y = (0 + verticalOffset).dp)
+        TrayPosition.TOP_RIGHT -> WindowPosition(
+            x = (screenSize.width - windowWidth + horizontalOffset).dp,
+            y = (0 + verticalOffset).dp
+        )
+        TrayPosition.BOTTOM_LEFT -> WindowPosition(
+            x = (0 + horizontalOffset).dp,
+            y = (screenSize.height - windowHeight + verticalOffset).dp
+        )
         TrayPosition.BOTTOM_RIGHT -> WindowPosition(
-            x = (screenSize.width - windowWidth).dp,
-            y = (screenSize.height - windowHeight).dp
+            x = (screenSize.width - windowWidth + horizontalOffset).dp,
+            y = (screenSize.height - windowHeight + verticalOffset).dp
         )
     }
 }
 
-// New: per-instance variant used by Windows multi-tray
-fun getTrayWindowPositionForInstance(instanceId: String, windowWidth: Int, windowHeight: Int): WindowPosition {
+/** Variante par instance (Windows multi-tray, mac precise) + offsets */
+fun getTrayWindowPositionForInstance(
+    instanceId: String,
+    windowWidth: Int,
+    windowHeight: Int,
+    horizontalOffset: Int = 0,
+    verticalOffset: Int = 0
+): WindowPosition {
     val os = getOperatingSystem()
     val screenSize = Toolkit.getDefaultToolkit().screenSize
 
-    when (os) {
+    return when (os) {
         OperatingSystem.WINDOWS -> {
             val pos = TrayClickTracker.getLastClickPosition(instanceId)
-                ?: return fallbackCornerPosition(windowWidth, windowHeight)
-            return calculateWindowPositionFromClick(
+                ?: return fallbackCornerPosition(windowWidth, windowHeight, horizontalOffset, verticalOffset)
+            calculateWindowPositionFromClick(
                 pos.x, pos.y, pos.position,
                 windowWidth, windowHeight,
-                screenSize.width, screenSize.height
+                screenSize.width, screenSize.height,
+                horizontalOffset, verticalOffset
             )
         }
         OperatingSystem.MACOS -> {
-            // Try per-instance native query
             val trayStruct = MacTrayInitializer.getNativeTrayStruct(instanceId)
             if (trayStruct != null) {
                 val xRef = IntByReference()
                 val yRef = IntByReference()
                 val lib = MacTrayLoader.lib
-                val precise = try { lib.tray_get_status_item_position_for(trayStruct, xRef, yRef) != 0 } catch (_: Throwable) { false }
+                val precise = try {
+                    lib.tray_get_status_item_position_for(trayStruct, xRef, yRef) != 0
+                } catch (_: Throwable) { false }
                 val x = xRef.value
                 val y = yRef.value
                 if (precise) {
-                    // Prefer native region if available, else compute from halves
                     val regionStr = runCatching { lib.tray_get_status_item_region_for(trayStruct) }.getOrNull()
-                    val trayPos = if (regionStr != null) getMacTrayPosition(regionStr) else convertPositionToCorner(x, y, screenSize.width, screenSize.height)
+                    val trayPos = if (regionStr != null) getMacTrayPosition(regionStr)
+                    else convertPositionToCorner(x, y, screenSize.width, screenSize.height)
                     TrayClickTracker.setClickPosition(instanceId, x, y, trayPos)
                     return calculateWindowPositionFromClick(
                         x, y, trayPos,
                         windowWidth, windowHeight,
-                        screenSize.width, screenSize.height
+                        screenSize.width, screenSize.height,
+                        horizontalOffset, verticalOffset
                     )
                 }
             }
-            // Fallback to global estimation
-            return getTrayWindowPosition(windowWidth, windowHeight)
+            // Fallback global
+            getTrayWindowPosition(windowWidth, windowHeight, horizontalOffset, verticalOffset)
         }
-        else -> {
-            // Other OS: fall back to global logic
-            return getTrayWindowPosition(windowWidth, windowHeight)
-        }
+        else -> getTrayWindowPosition(windowWidth, windowHeight, horizontalOffset, verticalOffset)
     }
 }
 
 /**
- * Calculate window position based on exact click coordinates.
- * This positions the window centered horizontally on the click point (icon),
- * and vertically above or below based on tray position, while ensuring it stays within screen bounds.
+ * Calcule la position (x,y) depuis un clic précis + applique les offsets et un clamp aux bords écran.
  */
 private fun calculateWindowPositionFromClick(
     clickX: Int, clickY: Int, trayPosition: TrayPosition,
     windowWidth: Int, windowHeight: Int,
-    screenWidth: Int, screenHeight: Int
+    screenWidth: Int, screenHeight: Int,
+    horizontalOffset: Int,
+    verticalOffset: Int
 ): WindowPosition {
-
-    // Horizontal: center on the icon
     var x = clickX - (windowWidth / 2)
-
-    // Adjust if it goes off screen
-    if (x < 0) {
-        x = 0
-    } else if (x + windowWidth > screenWidth) {
-        x = screenWidth - windowWidth
-    }
-
-    // Vertical: depend on tray position (top or bottom)
     var y = if (trayPosition == TrayPosition.TOP_LEFT || trayPosition == TrayPosition.TOP_RIGHT) {
-        // Tray at top: position window below icon
         clickY
     } else {
-        // Tray at bottom: position window above icon
         clickY - windowHeight
     }
 
-    // Ensure window stays within screen bounds vertically
-    if (y < 0) {
-        y = 0
-    } else if (y + windowHeight > screenHeight) {
-        y = screenHeight - windowHeight
-    }
+    // Offsets utilisateur
+    x += horizontalOffset
+    y += verticalOffset
+
+    // Clamp écran
+    if (x < 0) x = 0 else if (x + windowWidth > screenWidth) x = screenWidth - windowWidth
+    if (y < 0) y = 0 else if (y + windowHeight > screenHeight) y = screenHeight - windowHeight
 
     return WindowPosition(x = x.dp, y = y.dp)
 }
 
-/**
- * Interroge la DLL native pour récupérer le coin (x, y) de la zone de notification Windows.
- */
-fun getNotificationAreaXYForWindows(): Pair<Int, Int> {
-    val xRef = IntByReference()
-    val yRef = IntByReference()
-
-    val precise = WindowsNativeTrayLibrary.tray_get_notification_icons_position(xRef, yRef) != 0
-
-    val x = xRef.value
-    val y = yRef.value
-
-    // On ne mémorise la coordonnée que si elle est fiable
-    if (precise) {
-        val trayPosition = getTrayPosition()          // TOP_LEFT, TOP_RIGHT, ...
-        TrayClickTracker.setClickPosition(x, y, trayPosition)
-    }
-
-    debugln {
-        "[TrayPosition] Notification area: ($x, $y) " +
-                if (precise) "[exact]" else "[fallback]"
-    }
-    return x to y
-}
-
-private fun fallbackCornerPosition(w: Int, h: Int): WindowPosition {
+/** Position de repli coin + offsets */
+private fun fallbackCornerPosition(
+    w: Int, h: Int,
+    horizontalOffset: Int,
+    verticalOffset: Int
+): WindowPosition {
     val screen = Toolkit.getDefaultToolkit().screenSize
     return when (getTrayPosition()) {
-        TrayPosition.TOP_LEFT     -> WindowPosition(0.dp, 0.dp)
-        TrayPosition.TOP_RIGHT    -> WindowPosition((screen.width - w).dp, 0.dp)
-        TrayPosition.BOTTOM_LEFT  -> WindowPosition(0.dp, (screen.height - h).dp)
+        TrayPosition.TOP_LEFT -> WindowPosition((0 + horizontalOffset).dp, (0 + verticalOffset).dp)
+        TrayPosition.TOP_RIGHT -> WindowPosition((screen.width - w + horizontalOffset).dp, (0 + verticalOffset).dp)
+        TrayPosition.BOTTOM_LEFT -> WindowPosition((0 + horizontalOffset).dp, (screen.height - h + verticalOffset).dp)
         TrayPosition.BOTTOM_RIGHT -> WindowPosition(
-            (screen.width - w).dp, (screen.height - h).dp
+            (screen.width - w + horizontalOffset).dp,
+            (screen.height - h + verticalOffset).dp
         )
     }
 }
 
 internal fun getMacTrayPosition(nativeResult: String?): TrayPosition = when (nativeResult) {
-    "top-left"     -> TrayPosition.TOP_LEFT
-    "top-right"    -> TrayPosition.TOP_RIGHT
-    // on ne verra jamais TOP/BOTTOM_BOTTOM sur mac, mais pour rester cohérent :
-    else           -> TrayPosition.TOP_RIGHT
+    "top-left"  -> TrayPosition.TOP_LEFT
+    "top-right" -> TrayPosition.TOP_RIGHT
+    else        -> TrayPosition.TOP_RIGHT
 }
 
 internal fun getStatusItemXYForMac(): Pair<Int, Int> {
     val xRef = IntByReference()
     val yRef = IntByReference()
     val lib = MacTrayLoader.lib
-
-    val precise = lib.tray_get_status_item_position(xRef, yRef) != 0
-    return xRef.value to yRef.value    // si !precise, valeurs = (0,0)
+    lib.tray_get_status_item_position(xRef, yRef) // if not precise, returns (0,0)
+    return xRef.value to yRef.value
 }
 
-/**
- * Debug utility to erase the tray properties file(s).
- * It attempts to delete the preferred file as well as legacy fallback locations
- * to ensure future loads don't pick stale values during debugging.
- */
 fun debugDeleteTrayPropertiesFiles() {
     val files = setOfNotNull(
         trayPropertiesFile(),
@@ -480,46 +385,27 @@ fun debugDeleteTrayPropertiesFiles() {
         oldTmpPropertiesFile(),
         macCachePropertiesFile()
     )
-
-    val deleted = files
-        .filter(File::exists)
-        .mapNotNull {
-            val deleted = runCatching { it.delete() }.getOrDefault(false)
-            it.absolutePath.takeIf { deleted }
-        }
-
-    debugln {
-        if (deleted.isNotEmpty()) {
-            "[debug] Deleted tray properties file(s): ${deleted.joinToString()}"
-        } else {
-            "[debug] No tray properties file found to delete: ${files.joinToString { it.absolutePath }}"
-        }
-    }
+    files.filter(File::exists).forEach { runCatching { it.delete() } }
 }
 
-
-// Computes a DPI-aware horizontal offset approximating half the tray icon width on Windows.
-// Standard 100% scale is 96 DPI; the historical constant was 15 px at 100%.
+// DPI helpers / hit-test utilities unchanged (kept here for completeness)
 private fun dpiAwareHalfIconOffset(): Int {
     return try {
         val dpi = Toolkit.getDefaultToolkit().screenResolution
         val scale = dpi / 96.0
         (15 * scale).roundToInt().coerceAtLeast(0)
-    } catch (t: Throwable) {
+    } catch (_: Throwable) {
         15
     }
 }
 
-
-// Returns true if the given AWT screen point (px,py) lies within the macOS status item (tray icon) area.
-// We approximate the icon bounds as a square centered at the native (x,y) with DPI-aware half-size.
 internal fun isPointWithinMacStatusItem(px: Int, py: Int): Boolean {
     if (getOperatingSystem() != OperatingSystem.MACOS) return false
     val (ix, iy) = getStatusItemXYForMac()
     if (ix == 0 && iy == 0) return false
-    val dpi = try { Toolkit.getDefaultToolkit().screenResolution } catch (_: Throwable) { 96 }
+    val dpi = runCatching { Toolkit.getDefaultToolkit().screenResolution }.getOrDefault(96)
     val scale = dpi / 96.0
-    val half = (14 * scale).roundToInt().coerceAtLeast(8) // ~28px at 1x, ~56px at 2x
+    val half = (14 * scale).roundToInt().coerceAtLeast(8)
     val left = ix - half
     val right = ix + half
     val top = iy - half
@@ -527,20 +413,10 @@ internal fun isPointWithinMacStatusItem(px: Int, py: Int): Boolean {
     return px in left..right && py in top..bottom
 }
 
-// Returns true if the given AWT screen point (px, py) lies within the Linux tray icon area.
-// We approximate the icon bounds as a square centered at the last known tray click position.
-// On Linux there isn't a stable public API to fetch the status item bounds across DEs,
-// so this uses a heuristic based on DE defaults and DPI scaling.
-// If we lack any remembered click coordinates, we conservatively return false.
 internal fun isPointWithinLinuxStatusItem(px: Int, py: Int): Boolean {
     if (getOperatingSystem() != OperatingSystem.LINUX) return false
-
-    // Prefer fresh in-memory click; fallback to persisted properties
     val click = TrayClickTracker.getLastClickPosition() ?: loadTrayClickPosition() ?: return false
     val (ix, iy) = click.x to click.y
-
-    // Determine a reasonable base icon size by DE (in logical px at 100% scale).
-    // GNOME/Cinnamon/MATE/XFCE commonly use 24–32 px; KDE often 22–24 px.
     val baseIconSizeAt1x = when (detectLinuxDesktopEnvironment()) {
         LinuxDesktopEnvironment.KDE      -> 22
         LinuxDesktopEnvironment.GNOME    -> 24
@@ -549,21 +425,13 @@ internal fun isPointWithinLinuxStatusItem(px: Int, py: Int): Boolean {
         LinuxDesktopEnvironment.XFCE     -> 24
         else                             -> 24
     }
-
-    // DPI scaling (96 DPI == 1.0). Guard for headless/odd setups.
     val dpi = runCatching { Toolkit.getDefaultToolkit().screenResolution }.getOrDefault(96)
-    val scale = (dpi / 96.0).coerceAtLeast(0.5) // avoid absurdly small/zero
-
-    // Half-size of the square around the icon center.
+    val scale = (dpi / 96.0).coerceAtLeast(0.5)
     val half = (baseIconSizeAt1x * 0.5 * scale).toInt().coerceAtLeast(8)
-
-    // A small tolerance to account for panel paddings/hover effects.
     val fudge = (4 * scale).toInt().coerceAtLeast(2)
-
     val left   = ix - half - fudge
     val right  = ix + half + fudge
     val top    = iy - half - fudge
     val bottom = iy + half + fudge
-
     return px in left..right && py in top..bottom
 }

--- a/src/commonMain/kotlin/com/kdroid/composetray/utils/TrayPosition.kt
+++ b/src/commonMain/kotlin/com/kdroid/composetray/utils/TrayPosition.kt
@@ -328,23 +328,29 @@ private fun calculateWindowPositionFromClick(
     horizontalOffset: Int,
     verticalOffset: Int
 ): WindowPosition {
+    val isTop = trayPosition == TrayPosition.TOP_LEFT || trayPosition == TrayPosition.TOP_RIGHT
+    val isRight = trayPosition == TrayPosition.TOP_RIGHT || trayPosition == TrayPosition.BOTTOM_RIGHT
+
     var x = clickX - (windowWidth / 2)
-    var y = if (trayPosition == TrayPosition.TOP_LEFT || trayPosition == TrayPosition.TOP_RIGHT) {
+    var y = if (isTop) {
+        // Anchor below the top bar
         clickY
     } else {
+        // Anchor above the bottom bar
         clickY - windowHeight
     }
 
-    // Offsets utilisateur
-    x += horizontalOffset
-    y += verticalOffset
+    // Direction-aware offsets: always push AWAY from the bar/edge.
+    x += if (isRight) -horizontalOffset else horizontalOffset
+    y += if (isTop)  verticalOffset   else -verticalOffset
 
-    // Clamp écran
+    // Clamp to screen
     if (x < 0) x = 0 else if (x + windowWidth > screenWidth) x = screenWidth - windowWidth
     if (y < 0) y = 0 else if (y + windowHeight > screenHeight) y = screenHeight - windowHeight
 
     return WindowPosition(x = x.dp, y = y.dp)
 }
+
 
 /** Position de repli coin + offsets */
 private fun fallbackCornerPosition(

--- a/src/commonMain/kotlin/com/kdroid/composetray/utils/TrayPosition.kt
+++ b/src/commonMain/kotlin/com/kdroid/composetray/utils/TrayPosition.kt
@@ -328,23 +328,26 @@ private fun calculateWindowPositionFromClick(
     horizontalOffset: Int,
     verticalOffset: Int
 ): WindowPosition {
+    // Snap to the bar edge instead of using the raw clickY.
+    // This removes the "top vs bottom of icon" discrepancy on GNOME.
     val isTop = trayPosition == TrayPosition.TOP_LEFT || trayPosition == TrayPosition.TOP_RIGHT
     val isRight = trayPosition == TrayPosition.TOP_RIGHT || trayPosition == TrayPosition.BOTTOM_RIGHT
 
-    var x = clickX - (windowWidth / 2)
-    var y = if (isTop) {
-        // Anchor below the top bar
-        clickY
-    } else {
-        // Anchor above the bottom bar
-        clickY - windowHeight
-    }
+    // Heuristic bar thickness in pixels (kept conservative; scaling-safe enough in practice)
+    val panelGuessPx = 28
 
-    // Direction-aware offsets: always push AWAY from the bar/edge.
+    // Horizontal: center on clickX, then apply direction-aware offset
+    var x = clickX - (windowWidth / 2)
+
+    // Vertical: snap to the bar edge; ignore clickY height within the icon
+    val anchorY = if (isTop) panelGuessPx else screenHeight - panelGuessPx
+    var y = if (isTop) anchorY else anchorY - windowHeight
+
+    // Direction-aware offsets: push away from the bar/edge for a consistent "gap".
     x += if (isRight) -horizontalOffset else horizontalOffset
     y += if (isTop)  verticalOffset   else -verticalOffset
 
-    // Clamp to screen
+    // Clamp to screen bounds
     if (x < 0) x = 0 else if (x + windowWidth > screenWidth) x = screenWidth - windowWidth
     if (y < 0) y = 0 else if (y + windowHeight > screenHeight) y = screenHeight - windowHeight
 


### PR DESCRIPTION
### Summary

This pull request focuses on improving the dialog positioning logic and animations in `TrayApp` across various platforms. The changes aim to refine user experience and ensure consistent behavior.

### Changes

- **Improved Cross-Platform Dialog Positioning**
  - Updated `defaultVerticalOffset` for macOS, KDE, and GNOME environments for consistent alignment.
  - Enhanced GNOME snapping logic with DPI-aware calculations.
  - Introduced OS-specific offsets and refined corner snapping behavior for dialogs.

- **Enhancements to `TrayApp` Animations**
  - Introduced `PersistentAnimatedVisibility` for seamless enter/exit transitions, avoiding layout disposal.
  - Added `graphicsLayer` and `animateEnterExit` for smoother animations.
  - Adjusted animation durations for all platforms, emphasizing Windows-specific transitions.
  - Consolidated default animations into reusable parameters for maintainability.

- **Miscellaneous Refactorings**
  - Removed unnecessary imports and improved code readability with modular helpers.
  - Refined layout measurement and direction-aware positioning logic.

