### PR TITLE
Fix the build-native job and update the maclib/build.sh

### DIFF
--- a/.github/workflows/publish-on-maven.yml
+++ b/.github/workflows/publish-on-maven.yml
@@ -15,11 +15,14 @@ jobs:
       matrix:
         include:
           - os: ubuntu-latest
-            command: bash linuxlib/build.sh
+            command: |
+              cd linuxlib && bash build.sh
           - os: macos-latest
-            command: bash maclib/build.sh
+            command: |
+              cd maclib && bash build.sh
           - os: windows-latest
-            command: cmd /c winlib/build.bat
+            command: |
+              cd winlib && cmd /c build.bat
 
     steps:
       - uses: actions/checkout@v4
@@ -48,7 +51,7 @@ jobs:
       - name: Download all native binaries
         uses: actions/download-artifact@v4
         with:
-          name: nativeLibs-*
+          pattern: nativeLibs-*
           path: ${{ env.NATIVE_LIBS_DIR }}
           merge-multiple: true
 

--- a/maclib/build.sh
+++ b/maclib/build.sh
@@ -5,9 +5,15 @@ set -e
 
 echo "Building MacTray library..."
 
+OUTPUT_DIR="${NATIVE_LIBS_OUTPUT_DIR}"
+echo "output dir for mac is: $OUTPUT_DIR"
+
 echo "Building for ARM64 (Apple Silicon)..."
 
-swiftc -emit-library -o ../src/commonMain/resources/darwin-aarch64/libMacTray.dylib \
+mkdir -p "$OUTPUT_DIR/darwin-aarch64"
+mkdir -p "$OUTPUT_DIR/darwin-x86-64"
+
+swiftc -emit-library -o "$OUTPUT_DIR/darwin-aarch64/libMacTray.dylib" \
     -module-name MacTray \
     -swift-version 5 \
     -target arm64-apple-macosx11.0 \
@@ -20,7 +26,7 @@ swiftc -emit-library -o ../src/commonMain/resources/darwin-aarch64/libMacTray.dy
 
 echo "Building for x86_64 (Intel)..."
 
-swiftc -emit-library -o ../src/commonMain/resources/darwin-x86-64/libMacTray.dylib \
+swiftc -emit-library -o "$OUTPUT_DIR/darwin-x86-64/libMacTray.dylib" \
     -module-name MacTray \
     -swift-version 5 \
     -target x86_64-apple-macosx11.0 \


### PR DESCRIPTION
Fix the `build-native` job and update the `maclib/build.sh` file to use `NATIVE_LIBS_OUTPUT_DIR` as the output directory.

### NOTE
Please update the `winlib` and `linuxlib` like how I did for `maclib` (otherwise only macOS will be bundled in the resources folder!)