### PR TITLE
feat: add keyboard shortcut hints to tray menu items

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -22,9 +22,13 @@ val version =
     }
 
 repositories {
-    mavenCentral()
-    maven("https://maven.pkg.jetbrains.space/public/p/compose/dev")
     google()
+    mavenCentral()
+    maven("https://maven.pkg.jetbrains.space/public/p/compose/dev") {
+        content {
+            includeGroupByRegex("org\\.jetbrains.*")
+        }
+    }
 }
 
 tasks.withType<DokkaTask>().configureEach {

--- a/demo/src/jvmMain/kotlin/com/kdroid/composetray/demo/DynamicIconsDemo.kt
+++ b/demo/src/jvmMain/kotlin/com/kdroid/composetray/demo/DynamicIconsDemo.kt
@@ -18,6 +18,8 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Window
 import androidx.compose.ui.window.application
+import com.kdroid.composetray.menu.api.Key
+import com.kdroid.composetray.menu.api.KeyShortcut
 import com.kdroid.composetray.tray.api.Tray
 import com.kdroid.composetray.utils.ComposeNativeTrayLoggingLevel
 import com.kdroid.composetray.utils.SingleInstanceManager
@@ -88,12 +90,12 @@ fun main() = application {
         ) {
             // Weather submenu with dynamic icon
             SubMenu(label = "Weather", icon = weatherIcon) {
-                Item(label = "Sunny", icon = Icons.Default.WbSunny) {
+                Item(label = "Sunny", icon = Icons.Default.WbSunny, shortcut = KeyShortcut(Key.Num1, meta = true)) {
                     println("$logTag: Weather set to Sunny")
                     weatherIcon = Icons.Default.WbSunny
                 }
                 
-                Item(label = "Cloudy", icon = Icons.Default.Cloud) {
+                Item(label = "Cloudy", icon = Icons.Default.Cloud, shortcut = KeyShortcut(Key.Num2, meta = true)) {
                     println("$logTag: Weather set to Cloudy")
                     weatherIcon = Icons.Default.Cloud
                 }
@@ -113,12 +115,12 @@ fun main() = application {
             
             // Music submenu with dynamic icon
             SubMenu(label = "Music", icon = musicIcon) {
-                Item(label = "Play", icon = Icons.Default.PlayArrow) {
+                Item(label = "Play", icon = Icons.Default.PlayArrow, shortcut = KeyShortcut(Key.P, meta = true)) {
                     println("$logTag: Music playing")
                     musicIcon = Icons.Default.PlayArrow
                 }
                 
-                Item(label = "Pause", icon = Icons.Default.Pause) {
+                Item(label = "Pause", icon = Icons.Default.Pause, shortcut = KeyShortcut(Key.P, meta = true, shift = true)) {
                     println("$logTag: Music paused")
                     musicIcon = Icons.Default.Pause
                 }
@@ -130,15 +132,15 @@ fun main() = application {
                 
                 Divider()
                 
-                Item(label = "Volume Up", icon = Icons.Default.VolumeUp) {
+                Item(label = "Volume Up", icon = Icons.Default.VolumeUp, shortcut = KeyShortcut(Key.UpArrow, meta = true)) {
                     println("$logTag: Volume increased")
                 }
                 
-                Item(label = "Volume Down", icon = Icons.Default.VolumeDown) {
+                Item(label = "Volume Down", icon = Icons.Default.VolumeDown, shortcut = KeyShortcut(Key.DownArrow, meta = true)) {
                     println("$logTag: Volume decreased")
                 }
                 
-                Item(label = "Mute", icon = Icons.Default.VolumeMute) {
+                Item(label = "Mute", icon = Icons.Default.VolumeMute, shortcut = KeyShortcut(Key.M, meta = true, shift = true)) {
                     println("$logTag: Volume muted")
                 }
             }
@@ -211,12 +213,12 @@ fun main() = application {
             
             Divider()
             
-            Item(label = "Hide in tray", icon = Icons.Default.VisibilityOff) {
+            Item(label = "Hide in tray", icon = Icons.Default.VisibilityOff, shortcut = KeyShortcut(Key.H, meta = true)) {
                 isWindowVisible = false
                 println("$logTag: Application hidden in tray")
             }
             
-            Item(label = "Exit", icon = Icons.Default.ExitToApp) {
+            Item(label = "Exit", icon = Icons.Default.ExitToApp, shortcut = KeyShortcut(Key.Q, meta = true)) {
                 println("$logTag: Exiting application")
                 dispose()
                 exitApplication()

--- a/src/jvmMain/kotlin/com/kdroid/composetray/lib/linux/LinuxNativeBridge.kt
+++ b/src/jvmMain/kotlin/com/kdroid/composetray/lib/linux/LinuxNativeBridge.kt
@@ -162,6 +162,16 @@ internal object LinuxNativeBridge {
         iconBytes: ByteArray,
     )
 
+    @JvmStatic external fun nativeItemSetShortcut(
+        handle: Long,
+        id: Int,
+        key: String,
+        ctrl: Boolean,
+        shift: Boolean,
+        alt: Boolean,
+        superMod: Boolean,
+    )
+
     // -- X11 outside-click watcher -----------------------------------------------
 
     /** Open X11 display. Returns handle, or 0 if X11 is unavailable. */

--- a/src/jvmMain/kotlin/com/kdroid/composetray/lib/linux/LinuxTrayManager.kt
+++ b/src/jvmMain/kotlin/com/kdroid/composetray/lib/linux/LinuxTrayManager.kt
@@ -363,9 +363,13 @@ internal class LinuxTrayManager(
             item.shortcut?.let { shortcut ->
                 runCatching {
                     native.nativeItemSetShortcut(
-                        trayHandle, id,
+                        trayHandle,
+                        id,
                         shortcut.toLinuxKey(),
-                        shortcut.ctrl, shortcut.shift, shortcut.alt, shortcut.meta,
+                        shortcut.ctrl,
+                        shortcut.shift,
+                        shortcut.alt,
+                        shortcut.meta,
                     )
                 }.onFailure { e -> warnln { "[LinuxTrayManager] Failed to set shortcut: ${e.message}" } }
             }

--- a/src/jvmMain/kotlin/com/kdroid/composetray/lib/linux/LinuxTrayManager.kt
+++ b/src/jvmMain/kotlin/com/kdroid/composetray/lib/linux/LinuxTrayManager.kt
@@ -36,6 +36,7 @@ internal class LinuxTrayManager(
         val isCheckable: Boolean = false,
         val isChecked: Boolean = false,
         val iconPath: String? = null,
+        val shortcut: com.kdroid.composetray.menu.api.KeyShortcut? = null,
         val onClick: (() -> Unit)? = null,
         val subMenuItems: List<MenuItem> = emptyList(),
     )
@@ -356,6 +357,17 @@ internal class LinuxTrayManager(
                     val bytes = File(iconPath).takeIf { it.isFile }?.readBytes()
                     if (bytes != null) native.nativeItemSetIcon(trayHandle, id, bytes)
                 }.onFailure { e -> warnln { "[LinuxTrayManager] Failed to set menu item icon: ${e.message}" } }
+            }
+
+            // Keyboard shortcut hint
+            item.shortcut?.let { shortcut ->
+                runCatching {
+                    native.nativeItemSetShortcut(
+                        trayHandle, id,
+                        shortcut.toLinuxKey(),
+                        shortcut.ctrl, shortcut.shift, shortcut.alt, shortcut.meta,
+                    )
+                }.onFailure { e -> warnln { "[LinuxTrayManager] Failed to set shortcut: ${e.message}" } }
             }
 
             // Submenu

--- a/src/jvmMain/kotlin/com/kdroid/composetray/lib/mac/MacNativeBridge.kt
+++ b/src/jvmMain/kotlin/com/kdroid/composetray/lib/mac/MacNativeBridge.kt
@@ -76,6 +76,13 @@ internal object MacNativeBridge {
         callback: Runnable?,
     )
 
+    @JvmStatic external fun nativeSetMenuItemShortcut(
+        menuHandle: Long,
+        index: Int,
+        keyEquivalent: String?,
+        modifierMask: Long,
+    )
+
     @JvmStatic external fun nativeSetMenuItemSubmenu(
         menuHandle: Long,
         index: Int,

--- a/src/jvmMain/kotlin/com/kdroid/composetray/lib/mac/MacTrayManager.kt
+++ b/src/jvmMain/kotlin/com/kdroid/composetray/lib/mac/MacTrayManager.kt
@@ -1,12 +1,12 @@
 package com.kdroid.composetray.lib.mac
 
 import androidx.compose.runtime.mutableStateOf
+import com.kdroid.composetray.menu.api.KeyShortcut
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.launch
-import com.kdroid.composetray.menu.api.KeyShortcut
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.locks.ReentrantLock

--- a/src/jvmMain/kotlin/com/kdroid/composetray/lib/mac/MacTrayManager.kt
+++ b/src/jvmMain/kotlin/com/kdroid/composetray/lib/mac/MacTrayManager.kt
@@ -6,6 +6,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.launch
+import com.kdroid.composetray.menu.api.KeyShortcut
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.locks.ReentrantLock
@@ -43,6 +44,7 @@ internal class MacTrayManager(
         val isEnabled: Boolean = true,
         val isCheckable: Boolean = false,
         val isChecked: Boolean = false,
+        val shortcut: KeyShortcut? = null,
         val onClick: (() -> Unit)? = null,
         val subMenuItems: List<MenuItem> = emptyList(),
     )
@@ -282,6 +284,15 @@ internal class MacTrayManager(
             if (menuItem.isEnabled) 0 else 1,
             if (menuItem.isChecked) 1 else 0,
         )
+
+        menuItem.shortcut?.let { shortcut ->
+            MacNativeBridge.nativeSetMenuItemShortcut(
+                parentHandle,
+                index,
+                shortcut.toMacKeyEquivalent(),
+                shortcut.toMacModifierMask(),
+            )
+        }
 
         menuItem.onClick?.let { onClick ->
             MacNativeBridge.nativeSetMenuItemCallback(

--- a/src/jvmMain/kotlin/com/kdroid/composetray/menu/api/KeyShortcut.kt
+++ b/src/jvmMain/kotlin/com/kdroid/composetray/menu/api/KeyShortcut.kt
@@ -27,10 +27,10 @@ data class KeyShortcut(
      */
     internal fun toMacModifierMask(): Long {
         var mask = 0L
-        if (meta) mask = mask or (1L shl 20)   // NSEventModifierFlagCommand
-        if (shift) mask = mask or (1L shl 17)   // NSEventModifierFlagShift
-        if (alt) mask = mask or (1L shl 19)     // NSEventModifierFlagOption
-        if (ctrl) mask = mask or (1L shl 18)    // NSEventModifierFlagControl
+        if (meta) mask = mask or (1L shl 20) // NSEventModifierFlagCommand
+        if (shift) mask = mask or (1L shl 17) // NSEventModifierFlagShift
+        if (alt) mask = mask or (1L shl 19) // NSEventModifierFlagOption
+        if (ctrl) mask = mask or (1L shl 18) // NSEventModifierFlagControl
         return mask
     }
 
@@ -56,20 +56,57 @@ enum class Key(
     internal val macKeyEquivalent: String,
     internal val linuxKeyName: String,
 ) {
-    A("a", "a"), B("b", "b"), C("c", "c"), D("d", "d"), E("e", "e"),
-    F("f", "f"), G("g", "g"), H("h", "h"), I("i", "i"), J("j", "j"),
-    K("k", "k"), L("l", "l"), M("m", "m"), N("n", "n"), O("o", "o"),
-    P("p", "p"), Q("q", "q"), R("r", "r"), S("s", "s"), T("t", "t"),
-    U("u", "u"), V("v", "v"), W("w", "w"), X("x", "x"), Y("y", "y"),
+    A("a", "a"),
+    B("b", "b"),
+    C("c", "c"),
+    D("d", "d"),
+    E("e", "e"),
+    F("f", "f"),
+    G("g", "g"),
+    H("h", "h"),
+    I("i", "i"),
+    J("j", "j"),
+    K("k", "k"),
+    L("l", "l"),
+    M("m", "m"),
+    N("n", "n"),
+    O("o", "o"),
+    P("p", "p"),
+    Q("q", "q"),
+    R("r", "r"),
+    S("s", "s"),
+    T("t", "t"),
+    U("u", "u"),
+    V("v", "v"),
+    W("w", "w"),
+    X("x", "x"),
+    Y("y", "y"),
     Z("z", "z"),
 
-    Num0("0", "0"), Num1("1", "1"), Num2("2", "2"), Num3("3", "3"), Num4("4", "4"),
-    Num5("5", "5"), Num6("6", "6"), Num7("7", "7"), Num8("8", "8"), Num9("9", "9"),
+    Num0("0", "0"),
+    Num1("1", "1"),
+    Num2("2", "2"),
+    Num3("3", "3"),
+    Num4("4", "4"),
+    Num5("5", "5"),
+    Num6("6", "6"),
+    Num7("7", "7"),
+    Num8("8", "8"),
+    Num9("9", "9"),
 
     // Function keys (AppKit private-use Unicode)
-    F1("\uF704", "F1"), F2("\uF705", "F2"), F3("\uF706", "F3"), F4("\uF707", "F4"),
-    F5("\uF708", "F5"), F6("\uF709", "F6"), F7("\uF70A", "F7"), F8("\uF70B", "F8"),
-    F9("\uF70C", "F9"), F10("\uF70D", "F10"), F11("\uF70E", "F11"), F12("\uF70F", "F12"),
+    F1("\uF704", "F1"),
+    F2("\uF705", "F2"),
+    F3("\uF706", "F3"),
+    F4("\uF707", "F4"),
+    F5("\uF708", "F5"),
+    F6("\uF709", "F6"),
+    F7("\uF70A", "F7"),
+    F8("\uF70B", "F8"),
+    F9("\uF70C", "F9"),
+    F10("\uF70D", "F10"),
+    F11("\uF70E", "F11"),
+    F12("\uF70F", "F12"),
 
     // Special keys
     Return("\r", "Return"),

--- a/src/jvmMain/kotlin/com/kdroid/composetray/menu/api/KeyShortcut.kt
+++ b/src/jvmMain/kotlin/com/kdroid/composetray/menu/api/KeyShortcut.kt
@@ -7,7 +7,8 @@ package com.kdroid.composetray.menu.api
  * On macOS, the shortcut renders as native key equivalent glyphs (e.g. ⌘S, ⇧⌘N).
  * On Linux, the shortcut is serialized as a DBusMenu `shortcut` property
  * and rendered by the desktop environment's indicator renderer (KDE, GNOME, etc.).
- * On Windows, this is currently a no-op.
+ * On Windows, the shortcut renders as right-aligned accelerator text (e.g. Ctrl+S, Ctrl+Shift+N)
+ * using the native Win32 tab-separated text convention.
  *
  * Example:
  * ```
@@ -44,6 +45,20 @@ data class KeyShortcut(
      * Returns the DBusMenu key name for Linux shortcut hints.
      */
     internal fun toLinuxKey(): String = key.linuxKeyName
+
+    /**
+     * Returns the Windows accelerator display text (e.g. "Ctrl+S", "Ctrl+Shift+N").
+     * Used with the Win32 tab-separated text convention for menu items.
+     */
+    internal fun toWindowsAcceleratorText(): String {
+        val parts = mutableListOf<String>()
+        if (ctrl) parts.add("Ctrl")
+        if (meta) parts.add("Win")
+        if (alt) parts.add("Alt")
+        if (shift) parts.add("Shift")
+        parts.add(key.windowsDisplayName)
+        return parts.joinToString("+")
+    }
 }
 
 /**
@@ -51,87 +66,89 @@ data class KeyShortcut(
  *
  * @property macKeyEquivalent The string value passed to NSMenuItem.setKeyEquivalent on macOS.
  * @property linuxKeyName The DBusMenu key name string for Linux (follows XKB naming).
+ * @property windowsDisplayName The display name shown in Win32 menu accelerator text.
  */
 enum class Key(
     internal val macKeyEquivalent: String,
     internal val linuxKeyName: String,
+    internal val windowsDisplayName: String,
 ) {
-    A("a", "a"),
-    B("b", "b"),
-    C("c", "c"),
-    D("d", "d"),
-    E("e", "e"),
-    F("f", "f"),
-    G("g", "g"),
-    H("h", "h"),
-    I("i", "i"),
-    J("j", "j"),
-    K("k", "k"),
-    L("l", "l"),
-    M("m", "m"),
-    N("n", "n"),
-    O("o", "o"),
-    P("p", "p"),
-    Q("q", "q"),
-    R("r", "r"),
-    S("s", "s"),
-    T("t", "t"),
-    U("u", "u"),
-    V("v", "v"),
-    W("w", "w"),
-    X("x", "x"),
-    Y("y", "y"),
-    Z("z", "z"),
+    A("a", "a", "A"),
+    B("b", "b", "B"),
+    C("c", "c", "C"),
+    D("d", "d", "D"),
+    E("e", "e", "E"),
+    F("f", "f", "F"),
+    G("g", "g", "G"),
+    H("h", "h", "H"),
+    I("i", "i", "I"),
+    J("j", "j", "J"),
+    K("k", "k", "K"),
+    L("l", "l", "L"),
+    M("m", "m", "M"),
+    N("n", "n", "N"),
+    O("o", "o", "O"),
+    P("p", "p", "P"),
+    Q("q", "q", "Q"),
+    R("r", "r", "R"),
+    S("s", "s", "S"),
+    T("t", "t", "T"),
+    U("u", "u", "U"),
+    V("v", "v", "V"),
+    W("w", "w", "W"),
+    X("x", "x", "X"),
+    Y("y", "y", "Y"),
+    Z("z", "z", "Z"),
 
-    Num0("0", "0"),
-    Num1("1", "1"),
-    Num2("2", "2"),
-    Num3("3", "3"),
-    Num4("4", "4"),
-    Num5("5", "5"),
-    Num6("6", "6"),
-    Num7("7", "7"),
-    Num8("8", "8"),
-    Num9("9", "9"),
+    Num0("0", "0", "0"),
+    Num1("1", "1", "1"),
+    Num2("2", "2", "2"),
+    Num3("3", "3", "3"),
+    Num4("4", "4", "4"),
+    Num5("5", "5", "5"),
+    Num6("6", "6", "6"),
+    Num7("7", "7", "7"),
+    Num8("8", "8", "8"),
+    Num9("9", "9", "9"),
 
     // Function keys (AppKit private-use Unicode)
-    F1("\uF704", "F1"),
-    F2("\uF705", "F2"),
-    F3("\uF706", "F3"),
-    F4("\uF707", "F4"),
-    F5("\uF708", "F5"),
-    F6("\uF709", "F6"),
-    F7("\uF70A", "F7"),
-    F8("\uF70B", "F8"),
-    F9("\uF70C", "F9"),
-    F10("\uF70D", "F10"),
-    F11("\uF70E", "F11"),
-    F12("\uF70F", "F12"),
+    F1("\uF704", "F1", "F1"),
+    F2("\uF705", "F2", "F2"),
+    F3("\uF706", "F3", "F3"),
+    F4("\uF707", "F4", "F4"),
+    F5("\uF708", "F5", "F5"),
+    F6("\uF709", "F6", "F6"),
+    F7("\uF70A", "F7", "F7"),
+    F8("\uF70B", "F8", "F8"),
+    F9("\uF70C", "F9", "F9"),
+    F10("\uF70D", "F10", "F10"),
+    F11("\uF70E", "F11", "F11"),
+    F12("\uF70F", "F12", "F12"),
 
     // Special keys
-    Return("\r", "Return"),
-    Tab("\t", "Tab"),
-    Space(" ", "space"),
-    Escape("\u001B", "Escape"),
-    Delete("\u007F", "BackSpace"),
-    ForwardDelete("\uF728", "Delete"),
-    UpArrow("\uF700", "Up"),
-    DownArrow("\uF701", "Down"),
-    LeftArrow("\uF702", "Left"),
-    RightArrow("\uF703", "Right"),
-    Home("\uF729", "Home"),
-    End("\uF72B", "End"),
-    PageUp("\uF72C", "Page_Up"),
-    PageDown("\uF72D", "Page_Down"),
-    Minus("-", "minus"),
-    Equal("=", "equal"),
-    LeftBracket("[", "bracketleft"),
-    RightBracket("]", "bracketright"),
-    Backslash("\\", "backslash"),
-    Semicolon(";", "semicolon"),
-    Quote("'", "apostrophe"),
-    Comma(",", "comma"),
-    Period(".", "period"),
-    Slash("/", "slash"),
-    Backquote("`", "grave"),
+    Return("\r", "Return", "Enter"),
+    Tab("\t", "Tab", "Tab"),
+    Space(" ", "space", "Space"),
+    Escape("\u001B", "Escape", "Esc"),
+    Delete("\u007F", "BackSpace", "Backspace"),
+    ForwardDelete("\uF728", "Delete", "Del"),
+    UpArrow("\uF700", "Up", "Up"),
+    DownArrow("\uF701", "Down", "Down"),
+    LeftArrow("\uF702", "Left", "Left"),
+    RightArrow("\uF703", "Right", "Right"),
+    Home("\uF729", "Home", "Home"),
+    End("\uF72B", "End", "End"),
+    PageUp("\uF72C", "Page_Up", "PgUp"),
+    PageDown("\uF72D", "Page_Down", "PgDn"),
+    Minus("-", "minus", "-"),
+    Equal("=", "equal", "="),
+    LeftBracket("[", "bracketleft", "["),
+    RightBracket("]", "bracketright", "]"),
+    Backslash("\\", "backslash", "\\"),
+    Semicolon(";", "semicolon", ";"),
+    Quote("'", "apostrophe", "'"),
+    Comma(",", "comma", ","),
+    Period(".", "period", "."),
+    Slash("/", "slash", "/"),
+    Backquote("`", "grave", "`"),
 }

--- a/src/jvmMain/kotlin/com/kdroid/composetray/menu/api/KeyShortcut.kt
+++ b/src/jvmMain/kotlin/com/kdroid/composetray/menu/api/KeyShortcut.kt
@@ -5,7 +5,9 @@ package com.kdroid.composetray.menu.api
  * This is display-only — it does not register any global hotkey handler.
  *
  * On macOS, the shortcut renders as native key equivalent glyphs (e.g. ⌘S, ⇧⌘N).
- * On other platforms, this is currently a no-op.
+ * On Linux, the shortcut is serialized as a DBusMenu `shortcut` property
+ * and rendered by the desktop environment's indicator renderer (KDE, GNOME, etc.).
+ * On Windows, this is currently a no-op.
  *
  * Example:
  * ```
@@ -37,51 +39,62 @@ data class KeyShortcut(
      * Lowercase letter for regular key, special Unicode for function/special keys.
      */
     internal fun toMacKeyEquivalent(): String = key.macKeyEquivalent
+
+    /**
+     * Returns the DBusMenu key name for Linux shortcut hints.
+     */
+    internal fun toLinuxKey(): String = key.linuxKeyName
 }
 
 /**
  * Keyboard keys that can be used in [KeyShortcut].
  *
  * @property macKeyEquivalent The string value passed to NSMenuItem.setKeyEquivalent on macOS.
+ * @property linuxKeyName The DBusMenu key name string for Linux (follows XKB naming).
  */
-enum class Key(internal val macKeyEquivalent: String) {
-    A("a"), B("b"), C("c"), D("d"), E("e"), F("f"), G("g"), H("h"),
-    I("i"), J("j"), K("k"), L("l"), M("m"), N("n"), O("o"), P("p"),
-    Q("q"), R("r"), S("s"), T("t"), U("u"), V("v"), W("w"), X("x"),
-    Y("y"), Z("z"),
+enum class Key(
+    internal val macKeyEquivalent: String,
+    internal val linuxKeyName: String,
+) {
+    A("a", "a"), B("b", "b"), C("c", "c"), D("d", "d"), E("e", "e"),
+    F("f", "f"), G("g", "g"), H("h", "h"), I("i", "i"), J("j", "j"),
+    K("k", "k"), L("l", "l"), M("m", "m"), N("n", "n"), O("o", "o"),
+    P("p", "p"), Q("q", "q"), R("r", "r"), S("s", "s"), T("t", "t"),
+    U("u", "u"), V("v", "v"), W("w", "w"), X("x", "x"), Y("y", "y"),
+    Z("z", "z"),
 
-    Num0("0"), Num1("1"), Num2("2"), Num3("3"), Num4("4"),
-    Num5("5"), Num6("6"), Num7("7"), Num8("8"), Num9("9"),
+    Num0("0", "0"), Num1("1", "1"), Num2("2", "2"), Num3("3", "3"), Num4("4", "4"),
+    Num5("5", "5"), Num6("6", "6"), Num7("7", "7"), Num8("8", "8"), Num9("9", "9"),
 
     // Function keys (AppKit private-use Unicode)
-    F1("\uF704"), F2("\uF705"), F3("\uF706"), F4("\uF707"),
-    F5("\uF708"), F6("\uF709"), F7("\uF70A"), F8("\uF70B"),
-    F9("\uF70C"), F10("\uF70D"), F11("\uF70E"), F12("\uF70F"),
+    F1("\uF704", "F1"), F2("\uF705", "F2"), F3("\uF706", "F3"), F4("\uF707", "F4"),
+    F5("\uF708", "F5"), F6("\uF709", "F6"), F7("\uF70A", "F7"), F8("\uF70B", "F8"),
+    F9("\uF70C", "F9"), F10("\uF70D", "F10"), F11("\uF70E", "F11"), F12("\uF70F", "F12"),
 
     // Special keys
-    Return("\r"),
-    Tab("\t"),
-    Space(" "),
-    Escape("\u001B"),
-    Delete("\u007F"),
-    ForwardDelete("\uF728"),
-    UpArrow("\uF700"),
-    DownArrow("\uF701"),
-    LeftArrow("\uF702"),
-    RightArrow("\uF703"),
-    Home("\uF729"),
-    End("\uF72B"),
-    PageUp("\uF72C"),
-    PageDown("\uF72D"),
-    Minus("-"),
-    Equal("="),
-    LeftBracket("["),
-    RightBracket("]"),
-    Backslash("\\"),
-    Semicolon(";"),
-    Quote("'"),
-    Comma(","),
-    Period("."),
-    Slash("/"),
-    Backquote("`"),
+    Return("\r", "Return"),
+    Tab("\t", "Tab"),
+    Space(" ", "space"),
+    Escape("\u001B", "Escape"),
+    Delete("\u007F", "BackSpace"),
+    ForwardDelete("\uF728", "Delete"),
+    UpArrow("\uF700", "Up"),
+    DownArrow("\uF701", "Down"),
+    LeftArrow("\uF702", "Left"),
+    RightArrow("\uF703", "Right"),
+    Home("\uF729", "Home"),
+    End("\uF72B", "End"),
+    PageUp("\uF72C", "Page_Up"),
+    PageDown("\uF72D", "Page_Down"),
+    Minus("-", "minus"),
+    Equal("=", "equal"),
+    LeftBracket("[", "bracketleft"),
+    RightBracket("]", "bracketright"),
+    Backslash("\\", "backslash"),
+    Semicolon(";", "semicolon"),
+    Quote("'", "apostrophe"),
+    Comma(",", "comma"),
+    Period(".", "period"),
+    Slash("/", "slash"),
+    Backquote("`", "grave"),
 }

--- a/src/jvmMain/kotlin/com/kdroid/composetray/menu/api/KeyShortcut.kt
+++ b/src/jvmMain/kotlin/com/kdroid/composetray/menu/api/KeyShortcut.kt
@@ -1,0 +1,87 @@
+package com.kdroid.composetray.menu.api
+
+/**
+ * Represents a keyboard shortcut hint displayed alongside a menu item.
+ * This is display-only — it does not register any global hotkey handler.
+ *
+ * On macOS, the shortcut renders as native key equivalent glyphs (e.g. ⌘S, ⇧⌘N).
+ * On other platforms, this is currently a no-op.
+ *
+ * Example:
+ * ```
+ * Item("Save", shortcut = KeyShortcut(Key.S, meta = true)) { ... }
+ * Item("New Window", shortcut = KeyShortcut(Key.N, meta = true, shift = true)) { ... }
+ * ```
+ */
+data class KeyShortcut(
+    val key: Key,
+    val ctrl: Boolean = false,
+    val shift: Boolean = false,
+    val alt: Boolean = false,
+    val meta: Boolean = false,
+) {
+    /**
+     * Returns the macOS NSEventModifierFlags bitmask for this shortcut.
+     */
+    internal fun toMacModifierMask(): Long {
+        var mask = 0L
+        if (meta) mask = mask or (1L shl 20)   // NSEventModifierFlagCommand
+        if (shift) mask = mask or (1L shl 17)   // NSEventModifierFlagShift
+        if (alt) mask = mask or (1L shl 19)     // NSEventModifierFlagOption
+        if (ctrl) mask = mask or (1L shl 18)    // NSEventModifierFlagControl
+        return mask
+    }
+
+    /**
+     * Returns the key equivalent string for macOS NSMenuItem.
+     * Lowercase letter for regular key, special Unicode for function/special keys.
+     */
+    internal fun toMacKeyEquivalent(): String = key.macKeyEquivalent
+}
+
+/**
+ * Keyboard keys that can be used in [KeyShortcut].
+ *
+ * @property macKeyEquivalent The string value passed to NSMenuItem.setKeyEquivalent on macOS.
+ */
+enum class Key(internal val macKeyEquivalent: String) {
+    A("a"), B("b"), C("c"), D("d"), E("e"), F("f"), G("g"), H("h"),
+    I("i"), J("j"), K("k"), L("l"), M("m"), N("n"), O("o"), P("p"),
+    Q("q"), R("r"), S("s"), T("t"), U("u"), V("v"), W("w"), X("x"),
+    Y("y"), Z("z"),
+
+    Num0("0"), Num1("1"), Num2("2"), Num3("3"), Num4("4"),
+    Num5("5"), Num6("6"), Num7("7"), Num8("8"), Num9("9"),
+
+    // Function keys (AppKit private-use Unicode)
+    F1("\uF704"), F2("\uF705"), F3("\uF706"), F4("\uF707"),
+    F5("\uF708"), F6("\uF709"), F7("\uF70A"), F8("\uF70B"),
+    F9("\uF70C"), F10("\uF70D"), F11("\uF70E"), F12("\uF70F"),
+
+    // Special keys
+    Return("\r"),
+    Tab("\t"),
+    Space(" "),
+    Escape("\u001B"),
+    Delete("\u007F"),
+    ForwardDelete("\uF728"),
+    UpArrow("\uF700"),
+    DownArrow("\uF701"),
+    LeftArrow("\uF702"),
+    RightArrow("\uF703"),
+    Home("\uF729"),
+    End("\uF72B"),
+    PageUp("\uF72C"),
+    PageDown("\uF72D"),
+    Minus("-"),
+    Equal("="),
+    LeftBracket("["),
+    RightBracket("]"),
+    Backslash("\\"),
+    Semicolon(";"),
+    Quote("'"),
+    Comma(","),
+    Period("."),
+    Slash("/"),
+    Backquote("`"),
+}

--- a/src/jvmMain/kotlin/com/kdroid/composetray/menu/api/TrayMenuBuilder.kt
+++ b/src/jvmMain/kotlin/com/kdroid/composetray/menu/api/TrayMenuBuilder.kt
@@ -19,11 +19,13 @@ interface TrayMenuBuilder {
      *
      * @param label The text label for the menu item.
      * @param isEnabled Indicates whether the menu item is enabled. Defaults to true.
+     * @param shortcut Optional keyboard shortcut hint displayed next to the item. Display-only, does not register a hotkey.
      * @param onClick Lambda function to be invoked when the menu item is clicked. Defaults to an empty lambda.
      */
     fun Item(
         label: String,
         isEnabled: Boolean = true,
+        shortcut: KeyShortcut? = null,
         onClick: () -> Unit = {},
     )
 
@@ -34,6 +36,7 @@ interface TrayMenuBuilder {
      * @param iconContent A Composable function that defines the icon.
      * @param iconRenderProperties Properties for rendering the icon. Defaults to 16x16 for menu items.
      * @param isEnabled Indicates whether the menu item is enabled. Defaults to true.
+     * @param shortcut Optional keyboard shortcut hint displayed next to the item. Display-only, does not register a hotkey.
      * @param onClick Lambda function to be invoked when the menu item is clicked. Defaults to an empty lambda.
      */
     fun Item(
@@ -41,6 +44,7 @@ interface TrayMenuBuilder {
         iconContent: @Composable () -> Unit,
         iconRenderProperties: IconRenderProperties = IconRenderProperties.forMenuItem(),
         isEnabled: Boolean = true,
+        shortcut: KeyShortcut? = null,
         onClick: () -> Unit = {},
     )
 
@@ -52,6 +56,7 @@ interface TrayMenuBuilder {
      * @param iconTint Optional tint color for the icon. If null, adapts to menu theme.
      * @param iconRenderProperties Properties for rendering the icon. Defaults to 16x16 for menu items.
      * @param isEnabled Indicates whether the menu item is enabled. Defaults to true.
+     * @param shortcut Optional keyboard shortcut hint displayed next to the item. Display-only, does not register a hotkey.
      * @param onClick Lambda function to be invoked when the menu item is clicked. Defaults to an empty lambda.
      */
     fun Item(
@@ -60,6 +65,7 @@ interface TrayMenuBuilder {
         iconTint: Color? = null,
         iconRenderProperties: IconRenderProperties = IconRenderProperties.forMenuItem(),
         isEnabled: Boolean = true,
+        shortcut: KeyShortcut? = null,
         onClick: () -> Unit = {},
     )
 
@@ -70,6 +76,7 @@ interface TrayMenuBuilder {
      * @param icon The Painter to display as icon.
      * @param iconRenderProperties Properties for rendering the icon. Defaults to 16x16 for menu items.
      * @param isEnabled Indicates whether the menu item is enabled. Defaults to true.
+     * @param shortcut Optional keyboard shortcut hint displayed next to the item. Display-only, does not register a hotkey.
      * @param onClick Lambda function to be invoked when the menu item is clicked. Defaults to an empty lambda.
      */
     fun Item(
@@ -77,6 +84,7 @@ interface TrayMenuBuilder {
         icon: Painter,
         iconRenderProperties: IconRenderProperties = IconRenderProperties.forMenuItem(),
         isEnabled: Boolean = true,
+        shortcut: KeyShortcut? = null,
         onClick: () -> Unit = {},
     )
 
@@ -89,6 +97,7 @@ interface TrayMenuBuilder {
         icon: DrawableResource,
         iconRenderProperties: IconRenderProperties = IconRenderProperties.forMenuItem(),
         isEnabled: Boolean = true,
+        shortcut: KeyShortcut? = null,
         onClick: () -> Unit = {},
     )
 
@@ -100,12 +109,14 @@ interface TrayMenuBuilder {
      * @param checked The current checked state of the item.
      * @param onCheckedChange A lambda function called when the user toggles the item. The new checked state is passed as a parameter.
      * @param isEnabled Determines if the checkable item is enabled. Defaults to true.
+     * @param shortcut Optional keyboard shortcut hint displayed next to the item. Display-only, does not register a hotkey.
      */
     fun CheckableItem(
         label: String,
         checked: Boolean,
         onCheckedChange: (Boolean) -> Unit,
         isEnabled: Boolean = true,
+        shortcut: KeyShortcut? = null,
     )
 
     /**
@@ -117,6 +128,7 @@ interface TrayMenuBuilder {
      * @param checked The current checked state of the item.
      * @param onCheckedChange A lambda function called when the user toggles the item.
      * @param isEnabled Determines if the checkable item is enabled. Defaults to true.
+     * @param shortcut Optional keyboard shortcut hint displayed next to the item. Display-only, does not register a hotkey.
      */
     fun CheckableItem(
         label: String,
@@ -125,6 +137,7 @@ interface TrayMenuBuilder {
         checked: Boolean,
         onCheckedChange: (Boolean) -> Unit,
         isEnabled: Boolean = true,
+        shortcut: KeyShortcut? = null,
     )
 
     /**
@@ -137,6 +150,7 @@ interface TrayMenuBuilder {
      * @param checked The current checked state of the item.
      * @param onCheckedChange A lambda function called when the user toggles the item.
      * @param isEnabled Determines if the checkable item is enabled. Defaults to true.
+     * @param shortcut Optional keyboard shortcut hint displayed next to the item. Display-only, does not register a hotkey.
      */
     fun CheckableItem(
         label: String,
@@ -146,6 +160,7 @@ interface TrayMenuBuilder {
         checked: Boolean,
         onCheckedChange: (Boolean) -> Unit,
         isEnabled: Boolean = true,
+        shortcut: KeyShortcut? = null,
     )
 
     /**
@@ -157,6 +172,7 @@ interface TrayMenuBuilder {
      * @param checked The current checked state of the item.
      * @param onCheckedChange A lambda function called when the user toggles the item.
      * @param isEnabled Determines if the checkable item is enabled. Defaults to true.
+     * @param shortcut Optional keyboard shortcut hint displayed next to the item. Display-only, does not register a hotkey.
      */
     fun CheckableItem(
         label: String,
@@ -165,6 +181,7 @@ interface TrayMenuBuilder {
         checked: Boolean,
         onCheckedChange: (Boolean) -> Unit,
         isEnabled: Boolean = true,
+        shortcut: KeyShortcut? = null,
     )
 
     /**
@@ -178,6 +195,7 @@ interface TrayMenuBuilder {
         checked: Boolean,
         onCheckedChange: (Boolean) -> Unit,
         isEnabled: Boolean = true,
+        shortcut: KeyShortcut? = null,
     )
 
     /**

--- a/src/jvmMain/kotlin/com/kdroid/composetray/menu/impl/AwtTrayMenuBuilderImpl.kt
+++ b/src/jvmMain/kotlin/com/kdroid/composetray/menu/impl/AwtTrayMenuBuilderImpl.kt
@@ -4,6 +4,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.painter.Painter
 import androidx.compose.ui.graphics.vector.ImageVector
+import com.kdroid.composetray.menu.api.KeyShortcut
 import com.kdroid.composetray.menu.api.TrayMenuBuilder
 import com.kdroid.composetray.utils.IconRenderProperties
 import org.jetbrains.compose.resources.DrawableResource
@@ -19,6 +20,7 @@ internal class AwtTrayMenuBuilderImpl(
     override fun Item(
         label: String,
         isEnabled: Boolean,
+        shortcut: KeyShortcut?,
         onClick: () -> Unit,
     ) {
         val menuItem = MenuItem(label)
@@ -34,11 +36,10 @@ internal class AwtTrayMenuBuilderImpl(
         iconContent: @Composable () -> Unit,
         iconRenderProperties: IconRenderProperties,
         isEnabled: Boolean,
+        shortcut: KeyShortcut?,
         onClick: () -> Unit,
     ) {
-        // Minimal implementation to make it compile
-        // Actual icon integration will be handled by the issue creator
-        Item(label, isEnabled, onClick)
+        Item(label, isEnabled, shortcut, onClick)
     }
 
     override fun Item(
@@ -47,11 +48,10 @@ internal class AwtTrayMenuBuilderImpl(
         iconTint: Color?,
         iconRenderProperties: IconRenderProperties,
         isEnabled: Boolean,
+        shortcut: KeyShortcut?,
         onClick: () -> Unit,
     ) {
-        // Minimal implementation to make it compile
-        // Actual icon integration will be handled by the issue creator
-        Item(label, isEnabled, onClick)
+        Item(label, isEnabled, shortcut, onClick)
     }
 
     override fun Item(
@@ -59,11 +59,10 @@ internal class AwtTrayMenuBuilderImpl(
         icon: Painter,
         iconRenderProperties: IconRenderProperties,
         isEnabled: Boolean,
+        shortcut: KeyShortcut?,
         onClick: () -> Unit,
     ) {
-        // Minimal implementation to make it compile
-        // Actual icon integration will be handled by the issue creator
-        Item(label, isEnabled, onClick)
+        Item(label, isEnabled, shortcut, onClick)
     }
 
     override fun Item(
@@ -71,10 +70,10 @@ internal class AwtTrayMenuBuilderImpl(
         icon: DrawableResource,
         iconRenderProperties: IconRenderProperties,
         isEnabled: Boolean,
+        shortcut: KeyShortcut?,
         onClick: () -> Unit,
     ) {
-        // Minimal implementation to make it compile
-        Item(label, isEnabled, onClick)
+        Item(label, isEnabled, shortcut, onClick)
     }
 
     override fun CheckableItem(
@@ -82,6 +81,7 @@ internal class AwtTrayMenuBuilderImpl(
         checked: Boolean,
         onCheckedChange: (Boolean) -> Unit,
         isEnabled: Boolean,
+        shortcut: KeyShortcut?,
     ) {
         var currentChecked = checked
         val checkableMenuItem = MenuItem(getCheckableLabel(label, currentChecked))
@@ -104,10 +104,9 @@ internal class AwtTrayMenuBuilderImpl(
         checked: Boolean,
         onCheckedChange: (Boolean) -> Unit,
         isEnabled: Boolean,
+        shortcut: KeyShortcut?,
     ) {
-        // Minimal implementation to make it compile
-        // Actual icon integration will be handled by the issue creator
-        CheckableItem(label, checked, onCheckedChange, isEnabled)
+        CheckableItem(label, checked, onCheckedChange, isEnabled, shortcut)
     }
 
     override fun CheckableItem(
@@ -118,10 +117,9 @@ internal class AwtTrayMenuBuilderImpl(
         checked: Boolean,
         onCheckedChange: (Boolean) -> Unit,
         isEnabled: Boolean,
+        shortcut: KeyShortcut?,
     ) {
-        // Minimal implementation to make it compile
-        // Actual icon integration will be handled by the issue creator
-        CheckableItem(label, checked, onCheckedChange, isEnabled)
+        CheckableItem(label, checked, onCheckedChange, isEnabled, shortcut)
     }
 
     override fun CheckableItem(
@@ -131,10 +129,9 @@ internal class AwtTrayMenuBuilderImpl(
         checked: Boolean,
         onCheckedChange: (Boolean) -> Unit,
         isEnabled: Boolean,
+        shortcut: KeyShortcut?,
     ) {
-        // Minimal implementation to make it compile
-        // Actual icon integration will be handled by the issue creator
-        CheckableItem(label, checked, onCheckedChange, isEnabled)
+        CheckableItem(label, checked, onCheckedChange, isEnabled, shortcut)
     }
 
     override fun CheckableItem(
@@ -144,9 +141,9 @@ internal class AwtTrayMenuBuilderImpl(
         checked: Boolean,
         onCheckedChange: (Boolean) -> Unit,
         isEnabled: Boolean,
+        shortcut: KeyShortcut?,
     ) {
-        // Minimal implementation to make it compile
-        CheckableItem(label, checked, onCheckedChange, isEnabled)
+        CheckableItem(label, checked, onCheckedChange, isEnabled, shortcut)
     }
 
     override fun SubMenu(
@@ -167,8 +164,6 @@ internal class AwtTrayMenuBuilderImpl(
         isEnabled: Boolean,
         submenuContent: (TrayMenuBuilder.() -> Unit)?,
     ) {
-        // Minimal implementation to make it compile
-        // Actual icon integration will be handled by the issue creator
         SubMenu(label, isEnabled, submenuContent)
     }
 
@@ -180,8 +175,6 @@ internal class AwtTrayMenuBuilderImpl(
         isEnabled: Boolean,
         submenuContent: (TrayMenuBuilder.() -> Unit)?,
     ) {
-        // Minimal implementation to make it compile
-        // Actual icon integration will be handled by the issue creator
         SubMenu(label, isEnabled, submenuContent)
     }
 
@@ -192,8 +185,6 @@ internal class AwtTrayMenuBuilderImpl(
         isEnabled: Boolean,
         submenuContent: (TrayMenuBuilder.() -> Unit)?,
     ) {
-        // Minimal implementation to make it compile
-        // Actual icon integration will be handled by the issue creator
         SubMenu(label, isEnabled, submenuContent)
     }
 
@@ -204,7 +195,6 @@ internal class AwtTrayMenuBuilderImpl(
         isEnabled: Boolean,
         submenuContent: (TrayMenuBuilder.() -> Unit)?,
     ) {
-        // Minimal implementation to make it compile
         SubMenu(label, isEnabled, submenuContent)
     }
 

--- a/src/jvmMain/kotlin/com/kdroid/composetray/menu/impl/LinuxTrayMenuBuilderImpl.kt
+++ b/src/jvmMain/kotlin/com/kdroid/composetray/menu/impl/LinuxTrayMenuBuilderImpl.kt
@@ -9,6 +9,7 @@ import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.graphics.painter.Painter
 import androidx.compose.ui.graphics.vector.ImageVector
 import com.kdroid.composetray.lib.linux.LinuxTrayManager
+import com.kdroid.composetray.menu.api.KeyShortcut
 import com.kdroid.composetray.menu.api.TrayMenuBuilder
 import com.kdroid.composetray.utils.ComposableIconUtils
 import com.kdroid.composetray.utils.IconRenderProperties
@@ -33,6 +34,7 @@ internal class LinuxTrayMenuBuilderImpl(
     override fun Item(
         label: String,
         isEnabled: Boolean,
+        shortcut: KeyShortcut?,
         onClick: () -> Unit,
     ) {
         lock.withLock {
@@ -43,7 +45,7 @@ internal class LinuxTrayMenuBuilderImpl(
                     onClick = onClick,
                 )
             menuItems.add(menuItem)
-            persistentMenuItems.add(menuItem) // Store reference
+            persistentMenuItems.add(menuItem)
         }
     }
 
@@ -52,10 +54,10 @@ internal class LinuxTrayMenuBuilderImpl(
         iconContent: @Composable () -> Unit,
         iconRenderProperties: IconRenderProperties,
         isEnabled: Boolean,
+        shortcut: KeyShortcut?,
         onClick: () -> Unit,
     ) {
         lock.withLock {
-            // Render the composable icon to a PNG file
             val iconPath = ComposableIconUtils.renderComposableToPngFile(iconRenderProperties, iconContent)
 
             val menuItem =
@@ -76,9 +78,9 @@ internal class LinuxTrayMenuBuilderImpl(
         iconTint: Color?,
         iconRenderProperties: IconRenderProperties,
         isEnabled: Boolean,
+        shortcut: KeyShortcut?,
         onClick: () -> Unit,
     ) {
-        // Create composable content for the icon
         val iconContent: @Composable () -> Unit = {
             val isDark = isMenuBarInDarkMode()
 
@@ -96,8 +98,7 @@ internal class LinuxTrayMenuBuilderImpl(
             )
         }
 
-        // Delegate to the composable version
-        Item(label, iconContent, iconRenderProperties, isEnabled, onClick)
+        Item(label, iconContent, iconRenderProperties, isEnabled, shortcut, onClick)
     }
 
     override fun Item(
@@ -105,9 +106,9 @@ internal class LinuxTrayMenuBuilderImpl(
         icon: Painter,
         iconRenderProperties: IconRenderProperties,
         isEnabled: Boolean,
+        shortcut: KeyShortcut?,
         onClick: () -> Unit,
     ) {
-        // Create composable content for the painter
         val iconContent: @Composable () -> Unit = {
             Image(
                 painter = icon,
@@ -116,8 +117,7 @@ internal class LinuxTrayMenuBuilderImpl(
             )
         }
 
-        // Delegate to the composable version
-        Item(label, iconContent, iconRenderProperties, isEnabled, onClick)
+        Item(label, iconContent, iconRenderProperties, isEnabled, shortcut, onClick)
     }
 
     override fun Item(
@@ -125,6 +125,7 @@ internal class LinuxTrayMenuBuilderImpl(
         icon: DrawableResource,
         iconRenderProperties: IconRenderProperties,
         isEnabled: Boolean,
+        shortcut: KeyShortcut?,
         onClick: () -> Unit,
     ) {
         val iconContent: @Composable () -> Unit = {
@@ -134,7 +135,7 @@ internal class LinuxTrayMenuBuilderImpl(
                 modifier = Modifier.fillMaxSize(),
             )
         }
-        Item(label, iconContent, iconRenderProperties, isEnabled, onClick)
+        Item(label, iconContent, iconRenderProperties, isEnabled, shortcut, onClick)
     }
 
     override fun CheckableItem(
@@ -142,11 +143,9 @@ internal class LinuxTrayMenuBuilderImpl(
         checked: Boolean,
         onCheckedChange: (Boolean) -> Unit,
         isEnabled: Boolean,
+        shortcut: KeyShortcut?,
     ) {
         lock.withLock {
-            // Create a mutable reference to the current checked state
-            // This will be used in the onClick callback to get the current state
-            // instead of capturing the initial state
             val initialChecked = checked
 
             val menuItem =
@@ -157,22 +156,17 @@ internal class LinuxTrayMenuBuilderImpl(
                     isChecked = initialChecked,
                     onClick = {
                         lock.withLock {
-                            // Find the current menu item to get its current state
                             val currentMenuItem = menuItems.find { it.text == label }
-                            // Toggle based on the current state, not the initial state
                             val currentChecked = currentMenuItem?.isChecked ?: initialChecked
                             val newChecked = !currentChecked
 
-                            // Call the onCheckedChange callback with the new state
                             onCheckedChange(newChecked)
-
-                            // Update the tray manager to reflect the new state
                             trayManager?.updateMenuItemCheckedState(label, newChecked)
                         }
                     },
                 )
             menuItems.add(menuItem)
-            persistentMenuItems.add(menuItem) // Store reference
+            persistentMenuItems.add(menuItem)
         }
     }
 
@@ -183,9 +177,9 @@ internal class LinuxTrayMenuBuilderImpl(
         checked: Boolean,
         onCheckedChange: (Boolean) -> Unit,
         isEnabled: Boolean,
+        shortcut: KeyShortcut?,
     ) {
         lock.withLock {
-            // Render the composable icon to a PNG file
             val iconPath = ComposableIconUtils.renderComposableToPngFile(iconRenderProperties, iconContent)
 
             val initialChecked = checked
@@ -221,8 +215,8 @@ internal class LinuxTrayMenuBuilderImpl(
         checked: Boolean,
         onCheckedChange: (Boolean) -> Unit,
         isEnabled: Boolean,
+        shortcut: KeyShortcut?,
     ) {
-        // Create composable content for the icon
         val iconContent: @Composable () -> Unit = {
             val isDark = isMenuBarInDarkMode()
 
@@ -240,8 +234,7 @@ internal class LinuxTrayMenuBuilderImpl(
             )
         }
 
-        // Delegate to the composable version
-        CheckableItem(label, iconContent, iconRenderProperties, checked, onCheckedChange, isEnabled)
+        CheckableItem(label, iconContent, iconRenderProperties, checked, onCheckedChange, isEnabled, shortcut)
     }
 
     override fun CheckableItem(
@@ -251,8 +244,8 @@ internal class LinuxTrayMenuBuilderImpl(
         checked: Boolean,
         onCheckedChange: (Boolean) -> Unit,
         isEnabled: Boolean,
+        shortcut: KeyShortcut?,
     ) {
-        // Create composable content for the painter
         val iconContent: @Composable () -> Unit = {
             Image(
                 painter = icon,
@@ -261,8 +254,7 @@ internal class LinuxTrayMenuBuilderImpl(
             )
         }
 
-        // Delegate to the composable version
-        CheckableItem(label, iconContent, iconRenderProperties, checked, onCheckedChange, isEnabled)
+        CheckableItem(label, iconContent, iconRenderProperties, checked, onCheckedChange, isEnabled, shortcut)
     }
 
     override fun CheckableItem(
@@ -272,6 +264,7 @@ internal class LinuxTrayMenuBuilderImpl(
         checked: Boolean,
         onCheckedChange: (Boolean) -> Unit,
         isEnabled: Boolean,
+        shortcut: KeyShortcut?,
     ) {
         val iconContent: @Composable () -> Unit = {
             Image(
@@ -280,7 +273,7 @@ internal class LinuxTrayMenuBuilderImpl(
                 modifier = Modifier.fillMaxSize(),
             )
         }
-        CheckableItem(label, iconContent, iconRenderProperties, checked, onCheckedChange, isEnabled)
+        CheckableItem(label, iconContent, iconRenderProperties, checked, onCheckedChange, isEnabled, shortcut)
     }
 
     override fun SubMenu(
@@ -307,7 +300,7 @@ internal class LinuxTrayMenuBuilderImpl(
                     subMenuItems = subMenuItems,
                 )
             menuItems.add(subMenu)
-            persistentMenuItems.add(subMenu) // Store reference
+            persistentMenuItems.add(subMenu)
         }
     }
 
@@ -331,14 +324,12 @@ internal class LinuxTrayMenuBuilderImpl(
         }
 
         lock.withLock {
-            // Render the composable icon to a PNG file
             val iconPath = ComposableIconUtils.renderComposableToPngFile(iconRenderProperties, iconContent)
 
             val subMenu =
                 LinuxTrayManager.MenuItem(
                     text = label,
                     isEnabled = isEnabled,
-                    // Maintenant supporté !
                     iconPath = iconPath,
                     subMenuItems = subMenuItems,
                 )
@@ -355,7 +346,6 @@ internal class LinuxTrayMenuBuilderImpl(
         isEnabled: Boolean,
         submenuContent: (TrayMenuBuilder.() -> Unit)?,
     ) {
-        // Create composable content for the icon
         val iconContent: @Composable () -> Unit = {
             val isDark = isMenuBarInDarkMode()
             Image(
@@ -372,7 +362,6 @@ internal class LinuxTrayMenuBuilderImpl(
             )
         }
 
-        // Delegate to the composable version
         SubMenu(label, iconContent, iconRenderProperties, isEnabled, submenuContent)
     }
 
@@ -383,7 +372,6 @@ internal class LinuxTrayMenuBuilderImpl(
         isEnabled: Boolean,
         submenuContent: (TrayMenuBuilder.() -> Unit)?,
     ) {
-        // Create composable content for the painter
         val iconContent: @Composable () -> Unit = {
             Image(
                 painter = icon,
@@ -392,7 +380,6 @@ internal class LinuxTrayMenuBuilderImpl(
             )
         }
 
-        // Delegate to the composable version
         SubMenu(label, iconContent, iconRenderProperties, isEnabled, submenuContent)
     }
 
@@ -417,13 +404,12 @@ internal class LinuxTrayMenuBuilderImpl(
         lock.withLock {
             val divider = LinuxTrayManager.MenuItem(text = "-")
             menuItems.add(divider)
-            persistentMenuItems.add(divider) // Store reference
+            persistentMenuItems.add(divider)
         }
     }
 
     override fun dispose() {
         lock.withLock {
-            // Clear references when disposing
             persistentMenuItems.clear()
         }
     }

--- a/src/jvmMain/kotlin/com/kdroid/composetray/menu/impl/LinuxTrayMenuBuilderImpl.kt
+++ b/src/jvmMain/kotlin/com/kdroid/composetray/menu/impl/LinuxTrayMenuBuilderImpl.kt
@@ -42,6 +42,7 @@ internal class LinuxTrayMenuBuilderImpl(
                 LinuxTrayManager.MenuItem(
                     text = label,
                     isEnabled = isEnabled,
+                    shortcut = shortcut,
                     onClick = onClick,
                 )
             menuItems.add(menuItem)
@@ -65,6 +66,7 @@ internal class LinuxTrayMenuBuilderImpl(
                     text = label,
                     isEnabled = isEnabled,
                     iconPath = iconPath,
+                    shortcut = shortcut,
                     onClick = onClick,
                 )
             menuItems.add(menuItem)
@@ -154,6 +156,7 @@ internal class LinuxTrayMenuBuilderImpl(
                     isEnabled = isEnabled,
                     isCheckable = true,
                     isChecked = initialChecked,
+                    shortcut = shortcut,
                     onClick = {
                         lock.withLock {
                             val currentMenuItem = menuItems.find { it.text == label }
@@ -191,6 +194,7 @@ internal class LinuxTrayMenuBuilderImpl(
                     isCheckable = true,
                     isChecked = initialChecked,
                     iconPath = iconPath,
+                    shortcut = shortcut,
                     onClick = {
                         lock.withLock {
                             val currentMenuItem = menuItems.find { it.text == label }

--- a/src/jvmMain/kotlin/com/kdroid/composetray/menu/impl/MacTrayMenuBuilderImpl.kt
+++ b/src/jvmMain/kotlin/com/kdroid/composetray/menu/impl/MacTrayMenuBuilderImpl.kt
@@ -9,6 +9,7 @@ import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.graphics.painter.Painter
 import androidx.compose.ui.graphics.vector.ImageVector
 import com.kdroid.composetray.lib.mac.MacTrayManager
+import com.kdroid.composetray.menu.api.KeyShortcut
 import com.kdroid.composetray.menu.api.TrayMenuBuilder
 import com.kdroid.composetray.utils.ComposableIconUtils
 import com.kdroid.composetray.utils.IconRenderProperties
@@ -30,10 +31,10 @@ internal class MacTrayMenuBuilderImpl(
     // Maintain persistent references to prevent GC
     private val persistentMenuItems = mutableListOf<MacTrayManager.MenuItem>()
 
-    // Item without icon (existing method)
     override fun Item(
         label: String,
         isEnabled: Boolean,
+        shortcut: KeyShortcut?,
         onClick: () -> Unit,
     ) {
         lock.withLock {
@@ -42,6 +43,7 @@ internal class MacTrayMenuBuilderImpl(
                     text = label,
                     icon = null,
                     isEnabled = isEnabled,
+                    shortcut = shortcut,
                     onClick = onClick,
                 )
             menuItems.add(menuItem)
@@ -49,16 +51,15 @@ internal class MacTrayMenuBuilderImpl(
         }
     }
 
-    // Item with Composable icon
     override fun Item(
         label: String,
         iconContent: @Composable () -> Unit,
         iconRenderProperties: IconRenderProperties,
         isEnabled: Boolean,
+        shortcut: KeyShortcut?,
         onClick: () -> Unit,
     ) {
         lock.withLock {
-            // Render the composable icon to a PNG file
             val iconPath = ComposableIconUtils.renderComposableToPngFile(iconRenderProperties, iconContent)
 
             val menuItem =
@@ -66,6 +67,7 @@ internal class MacTrayMenuBuilderImpl(
                     text = label,
                     icon = iconPath,
                     isEnabled = isEnabled,
+                    shortcut = shortcut,
                     onClick = onClick,
                 )
             menuItems.add(menuItem)
@@ -73,18 +75,16 @@ internal class MacTrayMenuBuilderImpl(
         }
     }
 
-    // Item with ImageVector icon
     override fun Item(
         label: String,
         icon: ImageVector,
         iconTint: Color?,
         iconRenderProperties: IconRenderProperties,
         isEnabled: Boolean,
+        shortcut: KeyShortcut?,
         onClick: () -> Unit,
     ) {
-        // Create a composable that renders the ImageVector with appropriate tint
         val iconContent: @Composable () -> Unit = {
-            // Get the current menu bar theme
             val isDark = isSystemInDarkMode()
             Image(
                 imageVector = icon,
@@ -100,19 +100,17 @@ internal class MacTrayMenuBuilderImpl(
             )
         }
 
-        // Delegate to the composable version
-        Item(label, iconContent, iconRenderProperties, isEnabled, onClick)
+        Item(label, iconContent, iconRenderProperties, isEnabled, shortcut, onClick)
     }
 
-    // Item with Painter icon
     override fun Item(
         label: String,
         icon: Painter,
         iconRenderProperties: IconRenderProperties,
         isEnabled: Boolean,
+        shortcut: KeyShortcut?,
         onClick: () -> Unit,
     ) {
-        // Create a composable that renders the Painter
         val iconContent: @Composable () -> Unit = {
             Image(
                 painter = icon,
@@ -121,16 +119,15 @@ internal class MacTrayMenuBuilderImpl(
             )
         }
 
-        // Delegate to the composable version
-        Item(label, iconContent, iconRenderProperties, isEnabled, onClick)
+        Item(label, iconContent, iconRenderProperties, isEnabled, shortcut, onClick)
     }
 
-    // Item with DrawableResource icon
     override fun Item(
         label: String,
         icon: DrawableResource,
         iconRenderProperties: IconRenderProperties,
         isEnabled: Boolean,
+        shortcut: KeyShortcut?,
         onClick: () -> Unit,
     ) {
         val iconContent: @Composable () -> Unit = {
@@ -140,15 +137,15 @@ internal class MacTrayMenuBuilderImpl(
                 modifier = Modifier.fillMaxSize(),
             )
         }
-        Item(label, iconContent, iconRenderProperties, isEnabled, onClick)
+        Item(label, iconContent, iconRenderProperties, isEnabled, shortcut, onClick)
     }
 
-    // CheckableItem without icon (existing method)
     override fun CheckableItem(
         label: String,
         checked: Boolean,
         onCheckedChange: (Boolean) -> Unit,
         isEnabled: Boolean,
+        shortcut: KeyShortcut?,
     ) {
         lock.withLock {
             val menuItem =
@@ -158,14 +155,11 @@ internal class MacTrayMenuBuilderImpl(
                     isEnabled = isEnabled,
                     isCheckable = true,
                     isChecked = checked,
+                    shortcut = shortcut,
                     onClick = {
                         lock.withLock {
-                            // Toggle the checked state
                             val newChecked = !checked
                             onCheckedChange(newChecked)
-
-                            // Note: The actual visual update of the check mark
-                            // will happen when the menu is recreated after the state change
                         }
                     },
                 )
@@ -174,7 +168,6 @@ internal class MacTrayMenuBuilderImpl(
         }
     }
 
-    // CheckableItem with Composable icon
     override fun CheckableItem(
         label: String,
         iconContent: @Composable () -> Unit,
@@ -182,9 +175,9 @@ internal class MacTrayMenuBuilderImpl(
         checked: Boolean,
         onCheckedChange: (Boolean) -> Unit,
         isEnabled: Boolean,
+        shortcut: KeyShortcut?,
     ) {
         lock.withLock {
-            // Render the composable icon to a PNG file
             val iconPath = ComposableIconUtils.renderComposableToPngFile(iconRenderProperties, iconContent)
 
             val menuItem =
@@ -194,6 +187,7 @@ internal class MacTrayMenuBuilderImpl(
                     isEnabled = isEnabled,
                     isCheckable = true,
                     isChecked = checked,
+                    shortcut = shortcut,
                     onClick = {
                         lock.withLock {
                             val newChecked = !checked
@@ -206,7 +200,6 @@ internal class MacTrayMenuBuilderImpl(
         }
     }
 
-    // CheckableItem with ImageVector icon
     override fun CheckableItem(
         label: String,
         icon: ImageVector,
@@ -215,10 +208,9 @@ internal class MacTrayMenuBuilderImpl(
         checked: Boolean,
         onCheckedChange: (Boolean) -> Unit,
         isEnabled: Boolean,
+        shortcut: KeyShortcut?,
     ) {
-        // Create a composable that renders the ImageVector with appropriate tint
         val iconContent: @Composable () -> Unit = {
-            // Get the current menu bar theme
             val isDark = isSystemInDarkMode()
             Image(
                 imageVector = icon,
@@ -234,11 +226,9 @@ internal class MacTrayMenuBuilderImpl(
             )
         }
 
-        // Delegate to the composable version
-        CheckableItem(label, iconContent, iconRenderProperties, checked, onCheckedChange, isEnabled)
+        CheckableItem(label, iconContent, iconRenderProperties, checked, onCheckedChange, isEnabled, shortcut)
     }
 
-    // CheckableItem with Painter icon
     override fun CheckableItem(
         label: String,
         icon: Painter,
@@ -246,8 +236,8 @@ internal class MacTrayMenuBuilderImpl(
         checked: Boolean,
         onCheckedChange: (Boolean) -> Unit,
         isEnabled: Boolean,
+        shortcut: KeyShortcut?,
     ) {
-        // Create a composable that renders the Painter
         val iconContent: @Composable () -> Unit = {
             Image(
                 painter = icon,
@@ -256,11 +246,9 @@ internal class MacTrayMenuBuilderImpl(
             )
         }
 
-        // Delegate to the composable version
-        CheckableItem(label, iconContent, iconRenderProperties, checked, onCheckedChange, isEnabled)
+        CheckableItem(label, iconContent, iconRenderProperties, checked, onCheckedChange, isEnabled, shortcut)
     }
 
-    // CheckableItem with DrawableResource icon
     override fun CheckableItem(
         label: String,
         icon: DrawableResource,
@@ -268,6 +256,7 @@ internal class MacTrayMenuBuilderImpl(
         checked: Boolean,
         onCheckedChange: (Boolean) -> Unit,
         isEnabled: Boolean,
+        shortcut: KeyShortcut?,
     ) {
         val iconContent: @Composable () -> Unit = {
             Image(
@@ -276,10 +265,9 @@ internal class MacTrayMenuBuilderImpl(
                 modifier = Modifier.fillMaxSize(),
             )
         }
-        CheckableItem(label, iconContent, iconRenderProperties, checked, onCheckedChange, isEnabled)
+        CheckableItem(label, iconContent, iconRenderProperties, checked, onCheckedChange, isEnabled, shortcut)
     }
 
-    // SubMenu without icon (existing method)
     override fun SubMenu(
         label: String,
         isEnabled: Boolean,
@@ -288,7 +276,6 @@ internal class MacTrayMenuBuilderImpl(
         createSubMenu(label, null, isEnabled, submenuContent)
     }
 
-    // SubMenu with Composable icon
     override fun SubMenu(
         label: String,
         iconContent: @Composable () -> Unit,
@@ -296,12 +283,10 @@ internal class MacTrayMenuBuilderImpl(
         isEnabled: Boolean,
         submenuContent: (TrayMenuBuilder.() -> Unit)?,
     ) {
-        // Render the composable icon to a PNG file
         val iconPath = ComposableIconUtils.renderComposableToPngFile(iconRenderProperties, iconContent)
         createSubMenu(label, iconPath, isEnabled, submenuContent)
     }
 
-    // SubMenu with ImageVector icon
     override fun SubMenu(
         label: String,
         icon: ImageVector,
@@ -310,9 +295,7 @@ internal class MacTrayMenuBuilderImpl(
         isEnabled: Boolean,
         submenuContent: (TrayMenuBuilder.() -> Unit)?,
     ) {
-        // Create a composable that renders the ImageVector with appropriate tint
         val iconContent: @Composable () -> Unit = {
-            // Get the current menu bar theme
             val isDark = isSystemInDarkMode()
             Image(
                 imageVector = icon,
@@ -328,11 +311,9 @@ internal class MacTrayMenuBuilderImpl(
             )
         }
 
-        // Delegate to the composable version
         SubMenu(label, iconContent, iconRenderProperties, isEnabled, submenuContent)
     }
 
-    // SubMenu with Painter icon
     override fun SubMenu(
         label: String,
         icon: Painter,
@@ -340,7 +321,6 @@ internal class MacTrayMenuBuilderImpl(
         isEnabled: Boolean,
         submenuContent: (TrayMenuBuilder.() -> Unit)?,
     ) {
-        // Create a composable that renders the Painter
         val iconContent: @Composable () -> Unit = {
             Image(
                 painter = icon,
@@ -349,11 +329,9 @@ internal class MacTrayMenuBuilderImpl(
             )
         }
 
-        // Delegate to the composable version
         SubMenu(label, iconContent, iconRenderProperties, isEnabled, submenuContent)
     }
 
-    // SubMenu with DrawableResource icon
     override fun SubMenu(
         label: String,
         icon: DrawableResource,
@@ -371,7 +349,6 @@ internal class MacTrayMenuBuilderImpl(
         SubMenu(label, iconContent, iconRenderProperties, isEnabled, submenuContent)
     }
 
-    // Private helper method to create submenu
     private fun createSubMenu(
         label: String,
         iconPath: String?,
@@ -412,8 +389,6 @@ internal class MacTrayMenuBuilderImpl(
 
     override fun dispose() {
         lock.withLock {
-            // Just clear references when disposing
-            // The actual MacTrayManager instance is managed by MacTrayInitializer
             persistentMenuItems.clear()
         }
     }

--- a/src/jvmMain/kotlin/com/kdroid/composetray/menu/impl/WindowsTrayMenuBuilderImpl.kt
+++ b/src/jvmMain/kotlin/com/kdroid/composetray/menu/impl/WindowsTrayMenuBuilderImpl.kt
@@ -9,6 +9,7 @@ import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.graphics.painter.Painter
 import androidx.compose.ui.graphics.vector.ImageVector
 import com.kdroid.composetray.lib.windows.WindowsTrayManager
+import com.kdroid.composetray.menu.api.KeyShortcut
 import com.kdroid.composetray.menu.api.TrayMenuBuilder
 import com.kdroid.composetray.utils.ComposableIconUtils
 import com.kdroid.composetray.utils.IconRenderProperties
@@ -32,19 +33,19 @@ internal class WindowsTrayMenuBuilderImpl(
     override fun Item(
         label: String,
         isEnabled: Boolean,
+        shortcut: KeyShortcut?,
         onClick: () -> Unit,
     ) {
         lock.withLock {
             val menuItem =
                 WindowsTrayManager.MenuItem(
                     text = label,
-                    // No icon for basic item
                     iconPath = null,
                     isEnabled = isEnabled,
                     onClick = onClick,
                 )
             menuItems.add(menuItem)
-            persistentMenuItems.add(menuItem) // Store reference to prevent GC
+            persistentMenuItems.add(menuItem)
         }
     }
 
@@ -53,10 +54,10 @@ internal class WindowsTrayMenuBuilderImpl(
         iconContent: @Composable () -> Unit,
         iconRenderProperties: IconRenderProperties,
         isEnabled: Boolean,
+        shortcut: KeyShortcut?,
         onClick: () -> Unit,
     ) {
         lock.withLock {
-            // Render the composable icon to a PNG file (for future Windows icon support)
             val iconPath = ComposableIconUtils.renderComposableToIcoFile(iconRenderProperties, iconContent)
 
             val menuItem =
@@ -77,9 +78,9 @@ internal class WindowsTrayMenuBuilderImpl(
         iconTint: Color?,
         iconRenderProperties: IconRenderProperties,
         isEnabled: Boolean,
+        shortcut: KeyShortcut?,
         onClick: () -> Unit,
     ) {
-        // Create composable content for the icon
         val iconContent: @Composable () -> Unit = {
             val isDark = isMenuBarInDarkMode()
 
@@ -97,8 +98,7 @@ internal class WindowsTrayMenuBuilderImpl(
             )
         }
 
-        // Delegate to the composable version
-        Item(label, iconContent, iconRenderProperties, isEnabled, onClick)
+        Item(label, iconContent, iconRenderProperties, isEnabled, shortcut, onClick)
     }
 
     override fun Item(
@@ -106,9 +106,9 @@ internal class WindowsTrayMenuBuilderImpl(
         icon: Painter,
         iconRenderProperties: IconRenderProperties,
         isEnabled: Boolean,
+        shortcut: KeyShortcut?,
         onClick: () -> Unit,
     ) {
-        // Create composable content for the painter
         val iconContent: @Composable () -> Unit = {
             Image(
                 painter = icon,
@@ -117,8 +117,7 @@ internal class WindowsTrayMenuBuilderImpl(
             )
         }
 
-        // Delegate to the composable version
-        Item(label, iconContent, iconRenderProperties, isEnabled, onClick)
+        Item(label, iconContent, iconRenderProperties, isEnabled, shortcut, onClick)
     }
 
     override fun Item(
@@ -126,6 +125,7 @@ internal class WindowsTrayMenuBuilderImpl(
         icon: DrawableResource,
         iconRenderProperties: IconRenderProperties,
         isEnabled: Boolean,
+        shortcut: KeyShortcut?,
         onClick: () -> Unit,
     ) {
         val iconContent: @Composable () -> Unit = {
@@ -135,7 +135,7 @@ internal class WindowsTrayMenuBuilderImpl(
                 modifier = Modifier.fillMaxSize(),
             )
         }
-        Item(label, iconContent, iconRenderProperties, isEnabled, onClick)
+        Item(label, iconContent, iconRenderProperties, isEnabled, shortcut, onClick)
     }
 
     override fun CheckableItem(
@@ -143,6 +143,7 @@ internal class WindowsTrayMenuBuilderImpl(
         checked: Boolean,
         onCheckedChange: (Boolean) -> Unit,
         isEnabled: Boolean,
+        shortcut: KeyShortcut?,
     ) {
         lock.withLock {
             val menuItem =
@@ -153,13 +154,12 @@ internal class WindowsTrayMenuBuilderImpl(
                     isCheckable = true,
                     isChecked = checked,
                     onClick = {
-                        // Toggle the checked state
                         val newChecked = !checked
                         onCheckedChange(newChecked)
                     },
                 )
             menuItems.add(menuItem)
-            persistentMenuItems.add(menuItem) // Store reference to prevent GC
+            persistentMenuItems.add(menuItem)
         }
     }
 
@@ -170,9 +170,9 @@ internal class WindowsTrayMenuBuilderImpl(
         checked: Boolean,
         onCheckedChange: (Boolean) -> Unit,
         isEnabled: Boolean,
+        shortcut: KeyShortcut?,
     ) {
         lock.withLock {
-            // Render the composable icon to a PNG file (for future Windows icon support)
             val iconPath = ComposableIconUtils.renderComposableToIcoFile(iconRenderProperties, iconContent)
 
             val menuItem =
@@ -183,7 +183,6 @@ internal class WindowsTrayMenuBuilderImpl(
                     isCheckable = true,
                     isChecked = checked,
                     onClick = {
-                        // Toggle the checked state
                         val newChecked = !checked
                         onCheckedChange(newChecked)
                     },
@@ -201,8 +200,8 @@ internal class WindowsTrayMenuBuilderImpl(
         checked: Boolean,
         onCheckedChange: (Boolean) -> Unit,
         isEnabled: Boolean,
+        shortcut: KeyShortcut?,
     ) {
-        // Create composable content for the icon
         val iconContent: @Composable () -> Unit = {
             val isDark = isMenuBarInDarkMode()
 
@@ -220,8 +219,7 @@ internal class WindowsTrayMenuBuilderImpl(
             )
         }
 
-        // Delegate to the composable version
-        CheckableItem(label, iconContent, iconRenderProperties, checked, onCheckedChange, isEnabled)
+        CheckableItem(label, iconContent, iconRenderProperties, checked, onCheckedChange, isEnabled, shortcut)
     }
 
     override fun CheckableItem(
@@ -231,8 +229,8 @@ internal class WindowsTrayMenuBuilderImpl(
         checked: Boolean,
         onCheckedChange: (Boolean) -> Unit,
         isEnabled: Boolean,
+        shortcut: KeyShortcut?,
     ) {
-        // Create composable content for the painter
         val iconContent: @Composable () -> Unit = {
             Image(
                 painter = icon,
@@ -241,8 +239,7 @@ internal class WindowsTrayMenuBuilderImpl(
             )
         }
 
-        // Delegate to the composable version
-        CheckableItem(label, iconContent, iconRenderProperties, checked, onCheckedChange, isEnabled)
+        CheckableItem(label, iconContent, iconRenderProperties, checked, onCheckedChange, isEnabled, shortcut)
     }
 
     override fun CheckableItem(
@@ -252,6 +249,7 @@ internal class WindowsTrayMenuBuilderImpl(
         checked: Boolean,
         onCheckedChange: (Boolean) -> Unit,
         isEnabled: Boolean,
+        shortcut: KeyShortcut?,
     ) {
         val iconContent: @Composable () -> Unit = {
             Image(
@@ -260,7 +258,7 @@ internal class WindowsTrayMenuBuilderImpl(
                 modifier = Modifier.fillMaxSize(),
             )
         }
-        CheckableItem(label, iconContent, iconRenderProperties, checked, onCheckedChange, isEnabled)
+        CheckableItem(label, iconContent, iconRenderProperties, checked, onCheckedChange, isEnabled, shortcut)
     }
 
     override fun SubMenu(
@@ -278,7 +276,6 @@ internal class WindowsTrayMenuBuilderImpl(
         isEnabled: Boolean,
         submenuContent: (TrayMenuBuilder.() -> Unit)?,
     ) {
-        // Render the composable icon to a PNG file (for future Windows icon support)
         val iconPath = ComposableIconUtils.renderComposableToIcoFile(iconRenderProperties, iconContent)
         createSubMenu(label, iconPath, isEnabled, submenuContent)
     }
@@ -291,7 +288,6 @@ internal class WindowsTrayMenuBuilderImpl(
         isEnabled: Boolean,
         submenuContent: (TrayMenuBuilder.() -> Unit)?,
     ) {
-        // Create composable content for the icon
         val iconContent: @Composable () -> Unit = {
             val isDark = isMenuBarInDarkMode()
 
@@ -309,7 +305,6 @@ internal class WindowsTrayMenuBuilderImpl(
             )
         }
 
-        // Delegate to the composable version
         SubMenu(label, iconContent, iconRenderProperties, isEnabled, submenuContent)
     }
 
@@ -320,7 +315,6 @@ internal class WindowsTrayMenuBuilderImpl(
         isEnabled: Boolean,
         submenuContent: (TrayMenuBuilder.() -> Unit)?,
     ) {
-        // Create composable content for the painter
         val iconContent: @Composable () -> Unit = {
             Image(
                 painter = icon,
@@ -329,7 +323,6 @@ internal class WindowsTrayMenuBuilderImpl(
             )
         }
 
-        // Delegate to the composable version
         SubMenu(label, iconContent, iconRenderProperties, isEnabled, submenuContent)
     }
 
@@ -350,7 +343,6 @@ internal class WindowsTrayMenuBuilderImpl(
         SubMenu(label, iconContent, iconRenderProperties, isEnabled, submenuContent)
     }
 
-    // Private helper method to create submenu
     private fun createSubMenu(
         label: String,
         iconPath: String?,
@@ -376,7 +368,7 @@ internal class WindowsTrayMenuBuilderImpl(
                     subMenuItems = subMenuItems,
                 )
             menuItems.add(subMenu)
-            persistentMenuItems.add(subMenu) // Store reference to prevent GC
+            persistentMenuItems.add(subMenu)
         }
     }
 
@@ -384,7 +376,7 @@ internal class WindowsTrayMenuBuilderImpl(
         lock.withLock {
             val divider = WindowsTrayManager.MenuItem(text = "-")
             menuItems.add(divider)
-            persistentMenuItems.add(divider) // Store reference to prevent GC
+            persistentMenuItems.add(divider)
         }
     }
 
@@ -396,7 +388,7 @@ internal class WindowsTrayMenuBuilderImpl(
                 tooltip = tooltip,
                 onLeftClick = onLeftClick,
             ).stopTray()
-            persistentMenuItems.clear() // Clear references when disposing
+            persistentMenuItems.clear()
         }
     }
 

--- a/src/jvmMain/kotlin/com/kdroid/composetray/menu/impl/WindowsTrayMenuBuilderImpl.kt
+++ b/src/jvmMain/kotlin/com/kdroid/composetray/menu/impl/WindowsTrayMenuBuilderImpl.kt
@@ -39,7 +39,7 @@ internal class WindowsTrayMenuBuilderImpl(
         lock.withLock {
             val menuItem =
                 WindowsTrayManager.MenuItem(
-                    text = label,
+                    text = label.withShortcut(shortcut),
                     iconPath = null,
                     isEnabled = isEnabled,
                     onClick = onClick,
@@ -62,7 +62,7 @@ internal class WindowsTrayMenuBuilderImpl(
 
             val menuItem =
                 WindowsTrayManager.MenuItem(
-                    text = label,
+                    text = label.withShortcut(shortcut),
                     iconPath = iconPath,
                     isEnabled = isEnabled,
                     onClick = onClick,
@@ -148,7 +148,7 @@ internal class WindowsTrayMenuBuilderImpl(
         lock.withLock {
             val menuItem =
                 WindowsTrayManager.MenuItem(
-                    text = label,
+                    text = label.withShortcut(shortcut),
                     iconPath = null,
                     isEnabled = isEnabled,
                     isCheckable = true,
@@ -177,7 +177,7 @@ internal class WindowsTrayMenuBuilderImpl(
 
             val menuItem =
                 WindowsTrayManager.MenuItem(
-                    text = label,
+                    text = label.withShortcut(shortcut),
                     iconPath = iconPath,
                     isEnabled = isEnabled,
                     isCheckable = true,
@@ -393,4 +393,13 @@ internal class WindowsTrayMenuBuilderImpl(
     }
 
     fun build(): List<WindowsTrayManager.MenuItem> = lock.withLock { menuItems.toList() }
+
+    companion object {
+        /**
+         * Appends Win32 tab-separated accelerator text to a menu label.
+         * Windows natively right-aligns everything after `\t` in menu item strings.
+         */
+        private fun String.withShortcut(shortcut: KeyShortcut?): String =
+            if (shortcut != null) "$this\t${shortcut.toWindowsAcceleratorText()}" else this
+    }
 }

--- a/src/jvmMain/kotlin/com/kdroid/composetray/tray/api/NativeTray.kt
+++ b/src/jvmMain/kotlin/com/kdroid/composetray/tray/api/NativeTray.kt
@@ -66,7 +66,15 @@ internal class NativeTray {
 
         try {
             when (os) {
-                LINUX -> LinuxTrayInitializer.update(instanceId, iconPath, tooltip, primaryAction, menuContent, onMenuOpened)
+                LINUX ->
+                    LinuxTrayInitializer.update(
+                        instanceId,
+                        iconPath,
+                        tooltip,
+                        primaryAction,
+                        menuContent,
+                        onMenuOpened,
+                    )
                 WINDOWS ->
                     WindowsTrayInitializer.update(
                         instanceId,
@@ -76,7 +84,15 @@ internal class NativeTray {
                         menuContent,
                         onMenuOpened,
                     )
-                MACOS -> MacTrayInitializer.update(instanceId, iconPath, tooltip, primaryAction, menuContent, onMenuOpened)
+                MACOS ->
+                    MacTrayInitializer.update(
+                        instanceId,
+                        iconPath,
+                        tooltip,
+                        primaryAction,
+                        menuContent,
+                        onMenuOpened,
+                    )
                 UNKNOWN -> {
                     AwtTrayInitializer.update(iconPath, tooltip, primaryAction, menuContent)
                     awtTrayUsed.set(true)
@@ -143,7 +159,15 @@ internal class NativeTray {
                                 menuContent,
                                 onMenuOpened,
                             )
-                        MACOS -> MacTrayInitializer.update(instanceId, pngIconPath, tooltip, primaryAction, menuContent, onMenuOpened)
+                        MACOS ->
+                            MacTrayInitializer.update(
+                                instanceId,
+                                pngIconPath,
+                                tooltip,
+                                primaryAction,
+                                menuContent,
+                                onMenuOpened,
+                            )
                         UNKNOWN -> {
                             AwtTrayInitializer.update(pngIconPath, tooltip, primaryAction, menuContent)
                             awtTrayUsed.set(true)
@@ -255,7 +279,14 @@ internal class NativeTray {
                 when (os) {
                     LINUX -> {
                         debugln { "[NativeTray] Initializing Linux tray with icon path: $iconPath" }
-                        LinuxTrayInitializer.initialize(instanceId, iconPath, tooltip, primaryAction, menuContent, onMenuOpened)
+                        LinuxTrayInitializer.initialize(
+                            instanceId,
+                            iconPath,
+                            tooltip,
+                            primaryAction,
+                            menuContent,
+                            onMenuOpened,
+                        )
                         trayInitialized = true
                     }
                     WINDOWS -> {
@@ -272,7 +303,14 @@ internal class NativeTray {
                     }
                     MACOS -> {
                         debugln { "[NativeTray] Initializing macOS tray with icon path: $iconPath" }
-                        MacTrayInitializer.initialize(instanceId, iconPath, tooltip, primaryAction, menuContent, onMenuOpened)
+                        MacTrayInitializer.initialize(
+                            instanceId,
+                            iconPath,
+                            tooltip,
+                            primaryAction,
+                            menuContent,
+                            onMenuOpened,
+                        )
                         trayInitialized = true
                     }
                     else -> {}

--- a/src/jvmMain/kotlin/com/kdroid/composetray/utils/MenuContentHash.kt
+++ b/src/jvmMain/kotlin/com/kdroid/composetray/utils/MenuContentHash.kt
@@ -126,7 +126,8 @@ object MenuContentHash {
             shortcut: KeyShortcut?,
         ) {
             operations.add(
-                "CheckableItemWithImageVectorIcon:$label:${iconTint != null}:$checked:$isEnabled:${icon.hashCode()}:$shortcut",
+                "CheckableItemWithImageVectorIcon:$label:" +
+                    "${iconTint != null}:$checked:$isEnabled:${icon.hashCode()}:$shortcut",
             )
         }
 

--- a/src/jvmMain/kotlin/com/kdroid/composetray/utils/MenuContentHash.kt
+++ b/src/jvmMain/kotlin/com/kdroid/composetray/utils/MenuContentHash.kt
@@ -4,6 +4,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.painter.Painter
 import androidx.compose.ui.graphics.vector.ImageVector
+import com.kdroid.composetray.menu.api.KeyShortcut
 import com.kdroid.composetray.menu.api.TrayMenuBuilder
 import org.jetbrains.compose.resources.DrawableResource
 import java.security.MessageDigest
@@ -41,9 +42,10 @@ object MenuContentHash {
         override fun Item(
             label: String,
             isEnabled: Boolean,
+            shortcut: KeyShortcut?,
             onClick: () -> Unit,
         ) {
-            operations.add("Item:$label:$isEnabled")
+            operations.add("Item:$label:$isEnabled:$shortcut")
         }
 
         override fun Item(
@@ -51,9 +53,10 @@ object MenuContentHash {
             iconContent: @Composable () -> Unit,
             iconRenderProperties: IconRenderProperties,
             isEnabled: Boolean,
+            shortcut: KeyShortcut?,
             onClick: () -> Unit,
         ) {
-            operations.add("ItemWithComposableIcon:$label:$isEnabled")
+            operations.add("ItemWithComposableIcon:$label:$isEnabled:$shortcut")
         }
 
         override fun Item(
@@ -62,9 +65,10 @@ object MenuContentHash {
             iconTint: Color?,
             iconRenderProperties: IconRenderProperties,
             isEnabled: Boolean,
+            shortcut: KeyShortcut?,
             onClick: () -> Unit,
         ) {
-            operations.add("ItemWithImageVectorIcon:$label:${iconTint != null}:$isEnabled:${icon.hashCode()}")
+            operations.add("ItemWithImageVectorIcon:$label:${iconTint != null}:$isEnabled:${icon.hashCode()}:$shortcut")
         }
 
         override fun Item(
@@ -72,9 +76,10 @@ object MenuContentHash {
             icon: Painter,
             iconRenderProperties: IconRenderProperties,
             isEnabled: Boolean,
+            shortcut: KeyShortcut?,
             onClick: () -> Unit,
         ) {
-            operations.add("ItemWithPainterIcon:$label:$isEnabled:${icon.hashCode()}")
+            operations.add("ItemWithPainterIcon:$label:$isEnabled:${icon.hashCode()}:$shortcut")
         }
 
         override fun Item(
@@ -82,9 +87,10 @@ object MenuContentHash {
             icon: DrawableResource,
             iconRenderProperties: IconRenderProperties,
             isEnabled: Boolean,
+            shortcut: KeyShortcut?,
             onClick: () -> Unit,
         ) {
-            operations.add("ItemWithDrawableIcon:$label:$isEnabled:${icon.hashCode()}")
+            operations.add("ItemWithDrawableIcon:$label:$isEnabled:${icon.hashCode()}:$shortcut")
         }
 
         override fun CheckableItem(
@@ -92,8 +98,9 @@ object MenuContentHash {
             checked: Boolean,
             onCheckedChange: (Boolean) -> Unit,
             isEnabled: Boolean,
+            shortcut: KeyShortcut?,
         ) {
-            operations.add("CheckableItem:$label:$checked:$isEnabled")
+            operations.add("CheckableItem:$label:$checked:$isEnabled:$shortcut")
         }
 
         override fun CheckableItem(
@@ -103,8 +110,9 @@ object MenuContentHash {
             checked: Boolean,
             onCheckedChange: (Boolean) -> Unit,
             isEnabled: Boolean,
+            shortcut: KeyShortcut?,
         ) {
-            operations.add("CheckableItemWithComposableIcon:$label:$checked:$isEnabled")
+            operations.add("CheckableItemWithComposableIcon:$label:$checked:$isEnabled:$shortcut")
         }
 
         override fun CheckableItem(
@@ -115,9 +123,10 @@ object MenuContentHash {
             checked: Boolean,
             onCheckedChange: (Boolean) -> Unit,
             isEnabled: Boolean,
+            shortcut: KeyShortcut?,
         ) {
             operations.add(
-                "CheckableItemWithImageVectorIcon:$label:${iconTint != null}:$checked:$isEnabled:${icon.hashCode()}",
+                "CheckableItemWithImageVectorIcon:$label:${iconTint != null}:$checked:$isEnabled:${icon.hashCode()}:$shortcut",
             )
         }
 
@@ -128,8 +137,9 @@ object MenuContentHash {
             checked: Boolean,
             onCheckedChange: (Boolean) -> Unit,
             isEnabled: Boolean,
+            shortcut: KeyShortcut?,
         ) {
-            operations.add("CheckableItemWithPainterIcon:$label:$checked:$isEnabled:${icon.hashCode()}")
+            operations.add("CheckableItemWithPainterIcon:$label:$checked:$isEnabled:${icon.hashCode()}:$shortcut")
         }
 
         override fun CheckableItem(
@@ -139,8 +149,9 @@ object MenuContentHash {
             checked: Boolean,
             onCheckedChange: (Boolean) -> Unit,
             isEnabled: Boolean,
+            shortcut: KeyShortcut?,
         ) {
-            operations.add("CheckableItemWithDrawableIcon:$label:$checked:$isEnabled:${icon.hashCode()}")
+            operations.add("CheckableItemWithDrawableIcon:$label:$checked:$isEnabled:${icon.hashCode()}:$shortcut")
         }
 
         override fun SubMenu(

--- a/src/native/linux/jni_bridge.c
+++ b/src/native/linux/jni_bridge.c
@@ -513,6 +513,21 @@ Java_com_kdroid_composetray_lib_linux_LinuxNativeBridge_nativeItemSetIcon(
     (*env)->ReleaseByteArrayElements(env, iconBytes, buf, JNI_ABORT);
 }
 
+JNIEXPORT void JNICALL
+Java_com_kdroid_composetray_lib_linux_LinuxNativeBridge_nativeItemSetShortcut(
+    JNIEnv *env, jclass clazz, jlong handle, jint id,
+    jstring key, jboolean ctrl, jboolean shift, jboolean alt, jboolean superMod)
+{
+    (void)clazz;
+    sni_tray *tray = (sni_tray *)(uintptr_t)handle;
+    if (!tray) return;
+    const char *k = key ? (*env)->GetStringUTFChars(env, key, NULL) : NULL;
+    sni_tray_item_set_shortcut(tray, (uint32_t)id, k,
+                                ctrl ? 1 : 0, shift ? 1 : 0,
+                                alt ? 1 : 0, superMod ? 1 : 0);
+    if (k) (*env)->ReleaseStringUTFChars(env, key, k);
+}
+
 /* ========================================================================== */
 /*  X11 outside-click watcher (dynamically loaded to avoid hard dependency)   */
 /* ========================================================================== */

--- a/src/native/linux/sni.c
+++ b/src/native/linux/sni.c
@@ -67,6 +67,13 @@ typedef struct menu_item {
     uint8_t *icon_data;
     size_t   icon_len;
 
+    /* Keyboard shortcut hint (display-only, DBusMenu "shortcut" property) */
+    char    *shortcut_key;      /* e.g. "s", "F1", "Delete" */
+    int      shortcut_ctrl;
+    int      shortcut_shift;
+    int      shortcut_alt;
+    int      shortcut_super;    /* Meta key */
+
     /* Tree structure */
     int32_t  parent_id;  /* 0 = root */
     struct menu_item *children;
@@ -277,6 +284,7 @@ static void free_menu_items(sni_tray *tray) {
         free(tray->items[i].label);
         free(tray->items[i].tooltip);
         free(tray->items[i].icon_data);
+        free(tray->items[i].shortcut_key);
         free(tray->items[i].children);
     }
     free(tray->items);
@@ -626,6 +634,37 @@ static int append_menu_layout(sd_bus_message *reply, sni_tray *tray,
                     if (r < 0) return r;
                 }
 
+                /* Keyboard shortcut hint: DBusMenu "shortcut" property (type aas) */
+                if (item->shortcut_key) {
+                    r = sd_bus_message_open_container(reply, 'e', "sv");
+                    if (r < 0) return r;
+                    r = sd_bus_message_append(reply, "s", "shortcut");
+                    if (r < 0) return r;
+                    r = sd_bus_message_open_container(reply, 'v', "aas");
+                    if (r < 0) return r;
+                    r = sd_bus_message_open_container(reply, 'a', "as");
+                    if (r < 0) return r;
+                    r = sd_bus_message_open_container(reply, 'a', "s");
+                    if (r < 0) return r;
+                    if (item->shortcut_ctrl)
+                        sd_bus_message_append(reply, "s", "Control");
+                    if (item->shortcut_shift)
+                        sd_bus_message_append(reply, "s", "Shift");
+                    if (item->shortcut_alt)
+                        sd_bus_message_append(reply, "s", "Alt");
+                    if (item->shortcut_super)
+                        sd_bus_message_append(reply, "s", "Super");
+                    sd_bus_message_append(reply, "s", item->shortcut_key);
+                    r = sd_bus_message_close_container(reply); /* as (inner) */
+                    if (r < 0) return r;
+                    r = sd_bus_message_close_container(reply); /* a (outer) */
+                    if (r < 0) return r;
+                    r = sd_bus_message_close_container(reply); /* v */
+                    if (r < 0) return r;
+                    r = sd_bus_message_close_container(reply); /* e */
+                    if (r < 0) return r;
+                }
+
                 /* If this item has children, mark as submenu parent */
                 int32_t child_ids[MAX_MENU_ITEMS];
                 int child_count = get_children(tray, item_id, child_ids, MAX_MENU_ITEMS);
@@ -741,6 +780,26 @@ static int menu_get_group_properties(sd_bus_message *msg, void *userdata, sd_bus
                 if (item->checkable) {
                     sd_bus_message_append(reply, "{sv}", "toggle-type", "s", "checkmark");
                     sd_bus_message_append(reply, "{sv}", "toggle-state", "i", item->checked ? 1 : 0);
+                }
+                if (item->shortcut_key) {
+                    sd_bus_message_open_container(reply, 'e', "sv");
+                    sd_bus_message_append(reply, "s", "shortcut");
+                    sd_bus_message_open_container(reply, 'v', "aas");
+                    sd_bus_message_open_container(reply, 'a', "as");
+                    sd_bus_message_open_container(reply, 'a', "s");
+                    if (item->shortcut_ctrl)
+                        sd_bus_message_append(reply, "s", "Control");
+                    if (item->shortcut_shift)
+                        sd_bus_message_append(reply, "s", "Shift");
+                    if (item->shortcut_alt)
+                        sd_bus_message_append(reply, "s", "Alt");
+                    if (item->shortcut_super)
+                        sd_bus_message_append(reply, "s", "Super");
+                    sd_bus_message_append(reply, "s", item->shortcut_key);
+                    sd_bus_message_close_container(reply);
+                    sd_bus_message_close_container(reply);
+                    sd_bus_message_close_container(reply);
+                    sd_bus_message_close_container(reply);
                 }
             }
         }
@@ -1305,5 +1364,20 @@ void sni_tray_item_set_icon(sni_tray *tray, uint32_t id,
             item->icon_len = icon_len;
         }
     }
+    emit_layout_updated(tray);
+}
+
+void sni_tray_item_set_shortcut(sni_tray *tray, uint32_t id,
+                                 const char *key,
+                                 int ctrl, int shift, int alt, int super_mod) {
+    if (!tray) return;
+    menu_item *item = find_item(tray, (int32_t)id);
+    if (!item) return;
+    free(item->shortcut_key);
+    item->shortcut_key = key ? strdup(key) : NULL;
+    item->shortcut_ctrl = ctrl;
+    item->shortcut_shift = shift;
+    item->shortcut_alt = alt;
+    item->shortcut_super = super_mod;
     emit_layout_updated(tray);
 }

--- a/src/native/linux/sni.h
+++ b/src/native/linux/sni.h
@@ -97,6 +97,13 @@ void sni_tray_item_uncheck(sni_tray *tray, uint32_t id);
 void sni_tray_item_set_icon(sni_tray *tray, uint32_t id,
                              const uint8_t *icon_data, size_t icon_len);
 
+/* Set a display-only keyboard shortcut hint on a menu item.
+ * key: DBusMenu key name (e.g. "s", "F1", "Delete").
+ * Modifier flags: 1 = active, 0 = inactive. */
+void sni_tray_item_set_shortcut(sni_tray *tray, uint32_t id,
+                                 const char *key,
+                                 int ctrl, int shift, int alt, int super_mod);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/native/macos/MacTrayBridge.m
+++ b/src/native/macos/MacTrayBridge.m
@@ -405,6 +405,27 @@ JNIEXPORT void JNICALL Java_com_kdroid_composetray_lib_mac_MacNativeBridge_nativ
     item->cb = (callback != NULL) ? menuItemCbTrampoline : NULL;
 }
 
+JNIEXPORT void JNICALL Java_com_kdroid_composetray_lib_mac_MacNativeBridge_nativeSetMenuItemShortcut(
+    JNIEnv *env, jclass clazz, jlong menuHandle, jint index,
+    jstring keyEquivalent, jlong modifierMask)
+{
+    (void)clazz;
+    struct tray_menu_item *items = (struct tray_menu_item *)(uintptr_t)menuHandle;
+    if (!items) return;
+    struct tray_menu_item *item = &items[index];
+
+    free((void *)item->key_equivalent);
+
+    if (keyEquivalent != NULL) {
+        const char *utf = (*env)->GetStringUTFChars(env, keyEquivalent, NULL);
+        item->key_equivalent = strdup(utf);
+        (*env)->ReleaseStringUTFChars(env, keyEquivalent, utf);
+    } else {
+        item->key_equivalent = NULL;
+    }
+    item->key_equivalent_mod_mask = (unsigned long)modifierMask;
+}
+
 JNIEXPORT void JNICALL Java_com_kdroid_composetray_lib_mac_MacNativeBridge_nativeSetMenuItemSubmenu(
     JNIEnv *env, jclass clazz, jlong menuHandle, jint index, jlong submenuHandle)
 {
@@ -424,6 +445,7 @@ JNIEXPORT void JNICALL Java_com_kdroid_composetray_lib_mac_MacNativeBridge_nativ
         removeCallback(&g_menuCallbacks, &items[i]);
         free((void *)items[i].text);
         free((void *)items[i].icon_filepath);
+        free((void *)items[i].key_equivalent);
         /* Note: submenus are freed by their own nativeFreeMenuItems call */
     }
     free(items);

--- a/src/native/macos/tray.h
+++ b/src/native/macos/tray.h
@@ -41,6 +41,8 @@ struct tray_menu_item {
     int                      checked;      /* 1 = checked                     */
     tray_menu_item_callback  cb;          /* callback (NULL if none)         */
     struct tray_menu_item   *submenu;     /* submenu or NULL                 */
+    const char              *key_equivalent;        /* macOS key equivalent (e.g. "q") or NULL */
+    unsigned long            key_equivalent_mod_mask; /* macOS NSEventModifierFlags bitmask     */
 };
 
 struct tray {

--- a/src/native/macos/tray.swift
+++ b/src/native/macos/tray.swift
@@ -225,7 +225,14 @@ private func nativeMenu(from menuPtr: UnsafeMutableRawPointer, statusItem: NSSta
             let callback = currentPtr.advanced(by: 24).load(as: MenuItemCallback?.self)
             let submenu  = currentPtr.advanced(by: 32).load(as: UnsafeMutableRawPointer?.self)
 
-            let item = NSMenuItem(title: title, action: nil, keyEquivalent: "")
+            let keyEquivPtr = currentPtr.advanced(by: 40).load(as: UnsafePointer<CChar>?.self)
+            let keyEquivModMask = currentPtr.advanced(by: 48).load(as: UInt.self)
+
+            let keyEquiv = keyEquivPtr.flatMap({ String(cString: $0) }) ?? ""
+            let item = NSMenuItem(title: title, action: nil, keyEquivalent: keyEquiv)
+            if keyEquivPtr != nil {
+                item.keyEquivalentModifierMask = NSEvent.ModifierFlags(rawValue: keyEquivModMask)
+            }
             item.isEnabled = !disabled
             item.state = checked ? .on : .off
             item.representedObject = currentPtr
@@ -250,7 +257,7 @@ private func nativeMenu(from menuPtr: UnsafeMutableRawPointer, statusItem: NSSta
             }
         }
 
-        currentPtr = currentPtr.advanced(by: 40)  // Nouveau offset avec le champ icon_filepath
+        currentPtr = currentPtr.advanced(by: 56)  // Stride includes key_equivalent + mod_mask fields
     }
     return menu
 }

--- a/src/native/windows/tray.h
+++ b/src/native/windows/tray.h
@@ -44,6 +44,8 @@ struct tray_menu_item {
     int checked;
     void (*cb)(struct tray_menu_item *);
     struct tray_menu_item *submenu;
+    const char *key_equivalent;          // Reserved for future use (macOS only for now)
+    unsigned long key_equivalent_mod_mask; // Reserved for future use (macOS only for now)
 };
 
 /* -------------------------------------------------------------------------- */


### PR DESCRIPTION
## Summary

- Adds display-only keyboard shortcut hints for tray menu items (closes #174)
- On **macOS**, shortcuts render as native key equivalent glyphs (⌘, ⇧, ⌃, ⌥) via `NSMenuItem.keyEquivalent` / `keyEquivalentModifierMask`
- On **Windows** and **Linux**, the `shortcut` parameter is accepted but currently a no-op
- New `KeyShortcut` data class with `Key` enum covering letters, numbers, function keys, and special keys
- `TrayMenuBuilder.Item()` and `CheckableItem()` gain an optional `shortcut: KeyShortcut?` parameter

### API usage
```kotlin
Item("Save", shortcut = KeyShortcut(Key.S, meta = true)) { ... }
Item("New Window", shortcut = KeyShortcut(Key.N, meta = true, shift = true)) { ... }
```

## Test plan

- [x] Kotlin JVM compilation passes
- [x] macOS native dylib rebuilt with updated struct layout (stride 40 → 56)
- [x] DynamicIconsDemo runs with shortcut hints on macOS
- [x] Verify shortcut glyphs render correctly in tray menu on macOS
- [x] Verify Windows build is not broken by reserved struct fields
- [x] Verify Linux build is not broken