### PR TITLE
feat(trayapp): trim the heap after the popup is hidden

### DIFF
--- a/src/jvmMain/kotlin/dev/nucleusframework/composenativetray/tray/api/TrayApp.kt
+++ b/src/jvmMain/kotlin/dev/nucleusframework/composenativetray/tray/api/TrayApp.kt
@@ -63,6 +63,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import org.jetbrains.compose.resources.DrawableResource
 import org.jetbrains.compose.resources.painterResource
 import java.util.concurrent.atomic.AtomicLong
@@ -120,6 +121,29 @@ private val defaultVerticalOffset =
                 else -> 0
             }
     }
+
+private const val GC_AFTER_HIDE_DELAY_MS = 1_500L
+
+/**
+ * Trims the heap after the popup leaves the screen. The popup keeps its
+ * composition alive while hidden (so state survives hide/show), which means
+ * garbage from the visible session otherwise lingers for as long as the app
+ * idles in the tray — exactly the footprint users check in the task manager.
+ * Right after the exit animation there is no UI on screen, so the collection
+ * pause is invisible.
+ *
+ * Must be called from the visibility `LaunchedEffect`: reshowing the popup
+ * restarts the effect and cancels the [delay], debouncing rapid toggles for
+ * free. The collection runs off the UI thread so the tray loop only pays the
+ * stop-the-world portion.
+ */
+private suspend fun requestGcWhileHidden() {
+    delay(GC_AFTER_HIDE_DELAY_MS)
+    withContext(Dispatchers.Default) {
+        @Suppress("ExplicitGarbageCollectionCall")
+        System.gc()
+    }
+}
 
 // --------------------- Public API (overloads) ---------------------
 
@@ -661,6 +685,7 @@ private fun TrayAppImplPanel(
                 snapshotFlow { visibleState.isIdle && !visibleState.currentState }.first { it }
                 popupOnScreen = false
                 lastHiddenAtMs.set(System.currentTimeMillis())
+                requestGcWhileHidden()
             }
         }
     }
@@ -851,6 +876,7 @@ private fun NucleusApplicationScope.TrayAppImplWindow(
                 snapshotFlow { visibleState.isIdle && !visibleState.currentState }.first { it }
                 shouldShowWindow = false
                 lastHiddenAtMs.set(System.currentTimeMillis())
+                requestGcWhileHidden()
             }
         }
     }


### PR DESCRIPTION
## Summary
- The TrayApp popup keeps its composition alive while hidden (state survives hide/show), so garbage from the visible session lingers for as long as the app idles in the tray — exactly the footprint users check in the task manager.
- Trigger a GC ~1.5 s after the exit animation completes, in both implementations (standalone panel on Windows/macOS, window on Linux).
- No visible jank: nothing is on screen when the collection runs, it executes off the UI thread, and reshowing the popup restarts the visibility effect which cancels the pending delay — rapid toggles never GC.
- Audio-safe with native playback backends (e.g. composemediaplayer/rodio): their pipelines run on non-JVM threads, which JVM safepoints do not pause.

## Test plan
- [x] macOS: open popup, close it — memory drops ~2 s later, no visual glitch
- [ ] Rapid open/close toggles do not trigger repeated collections
- [ ] Linux window impl: same behavior on hide